### PR TITLE
[feat/#39] Button 컴포넌트 rem 단위로 변환하여 적용

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -6,6 +6,9 @@ import ButtonProps from "@/src/types/button";
 import clsx from "clsx";
 import { useEffect, useRef } from "react";
 
+const pxToRem = (px: string | undefined) =>
+  px ? `${parseFloat(px) / 16}rem` : undefined;
+
 const Button = ({
   type = "button",
   width,
@@ -36,10 +39,10 @@ const Button = ({
     <button
       type={type === "button" ? "button" : "submit"}
       style={{
-        width: `${width}px`,
-        height: `${height}px`,
-        borderRadius: `${radius}px`,
-        gap: `${gap}px`,
+        width: pxToRem(width),
+        height: pxToRem(height),
+        borderRadius: pxToRem(radius),
+        gap: pxToRem(gap),
       }}
       className={clsx(
         fullWidth && "w-full",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -37,7 +37,8 @@ const Button = ({
 
   return (
     <button
-      type={type === "button" ? "button" : "submit"}
+      // eslint-disable-next-line react/button-has-type
+      type={type}
       style={{
         width: pxToRem(width),
         height: pxToRem(height),

--- a/src/pages/button/index.tsx
+++ b/src/pages/button/index.tsx
@@ -6,9 +6,9 @@ import Button from "@/src/components/Button/Button";
 
 const button = () => {
   return (
-    <div className="flex flex-col gap-4 px-4 py-4">
+    <div className="flex flex-col gap-16 px-16 py-16">
       <p className="text-16px-semibold">🔻 로그인, 회원가입 페이지</p>
-      <div className="flex flex-col gap-1">
+      <div className="flex flex-col gap-4">
         <Button
           type="submit"
           height="48"
@@ -42,7 +42,7 @@ const button = () => {
         </Button>
       </div>
       <p className="text-16px-semibold">🔻 로그인, 회원가입 페이지_팝업</p>
-      <div className="flex gap-1">
+      <div className="flex gap-4">
         <Button
           type="button"
           width="120"
@@ -65,8 +65,8 @@ const button = () => {
         </Button>
       </div>
       <p className="text-16px-semibold">🔻 메인화면</p>
-      <div className="flex flex-col gap-1">
-        <div className="flex gap-1">
+      <div className="flex flex-col gap-4">
+        <div className="flex gap-4">
           <Button
             type="button"
             width="136"
@@ -88,7 +88,7 @@ const button = () => {
             검색하기
           </Button>
         </div>
-        <div className="flex gap-1">
+        <div className="flex gap-4">
           <Button
             type="button"
             width="127"
@@ -110,7 +110,7 @@ const button = () => {
             문화 · 예술
           </Button>
         </div>
-        <div className="flex gap-1">
+        <div className="flex gap-4">
           <Button
             type="button"
             width="55"
@@ -150,8 +150,8 @@ const button = () => {
         </div>
       </div>
       <p className="text-16px-semibold">🔻 체험 상세</p>
-      <div className="flex flex-col gap-1">
-        <div className="flex gap-1">
+      <div className="flex flex-col gap-4">
+        <div className="flex gap-4">
           <Button
             type="button"
             width="117"
@@ -173,7 +173,7 @@ const button = () => {
             15:00~16:00
           </Button>
         </div>
-        <div className="flex gap-1">
+        <div className="flex gap-4">
           <Button
             type="button"
             width="203"
@@ -196,7 +196,7 @@ const button = () => {
             예약하기
           </Button>
         </div>
-        <div className="flex gap-1">
+        <div className="flex gap-4">
           <Button
             type="button"
             height="56"
@@ -208,7 +208,7 @@ const button = () => {
             예약하기
           </Button>
         </div>
-        <div className="flex gap-1">
+        <div className="flex gap-4">
           <Button
             type="button"
             width="120"
@@ -232,7 +232,7 @@ const button = () => {
         </div>
       </div>
       <p className="text-16px-semibold">🔻 내 정보</p>
-      <div className="flex gap-1">
+      <div className="flex gap-4">
         <Button
           type="submit"
           width="120"
@@ -245,7 +245,7 @@ const button = () => {
         </Button>
       </div>
       <p className="text-16px-semibold">🔻 예약 내역</p>
-      <div className="flex gap-1">
+      <div className="flex gap-4">
         <Button
           type="button"
           width="144"
@@ -288,7 +288,7 @@ const button = () => {
         </Button>
       </div>
       <p className="text-16px-semibold">🔻 예약 내역</p>
-      <div className="flex gap-1">
+      <div className="flex gap-4">
         <Button
           type="button"
           height="56"
@@ -303,7 +303,7 @@ const button = () => {
       <p className="text-16px-semibold">
         🔻 체험 관리, 체험 등록, 내 체험 수정
       </p>
-      <div className="flex gap-1">
+      <div className="flex gap-4">
         <Button
           type="button"
           width="120"
@@ -336,7 +336,7 @@ const button = () => {
         </Button>
       </div>
       <p className="text-16px-semibold">🔻 예약 정보</p>
-      <div className="flex gap-1">
+      <div className="flex gap-4">
         <Button
           type="button"
           width="82"
@@ -359,7 +359,7 @@ const button = () => {
         </Button>
       </div>
       <p className="text-16px-semibold">🔻 알림</p>
-      <div className="flex gap-1">
+      <div className="flex gap-4">
         <Button type="button" width="24" height="24">
           <Close width={24} height={24} />
         </Button>

--- a/src/pages/button/index.tsx
+++ b/src/pages/button/index.tsx
@@ -360,10 +360,23 @@ const button = () => {
       </div>
       <p className="text-16px-semibold">🔻 알림</p>
       <div className="flex gap-4">
-        <Button type="button" width="24" height="24">
-          <Close width={24} height={24} />
-        </Button>
+        <form className="flex gap-4">
+          <input type="text" className="border" />
+          <Button
+            type="reset"
+            width="82"
+            height="38"
+            radius="6"
+            gap="8"
+            backgroundColor="white_black"
+            fontStyle="m">
+            초기화
+          </Button>
+        </form>
       </div>
+      <Button type="button" width="24" height="24">
+        <Close width={24} height={24} />
+      </Button>
     </div>
   );
 };

--- a/src/types/button.ts
+++ b/src/types/button.ts
@@ -9,11 +9,11 @@ export type ButtonColorType =
 export type ButtonTextSizeType = "s" | "m" | "l" | "xl" | "xxl" | "xxxl";
 
 interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
-  type: "button" | "submit";
+  type: "button" | "submit" | "reset";
   width?: string;
   height?: string;
   fullWidth?: boolean;
-  radius?: "4" | "6" | "8" | "9" | "15";
+  radius?: "4" | "6" | "8" | "9" | "15" | "20";
   gap?: "4" | "8" | "10";
   backgroundColor?: ButtonColorType;
   fontStyle?: ButtonTextSizeType;


### PR DESCRIPTION
## 🔨 수정 내역
### 1-1. 시도
`tailwindcss-preset-px-to-rem`를 적용하기 위하여 `https://jjang-j.tistory.com/150`를 참고하여 작성

<br/>

### 1-2. 결과
`gap-4`처럼 고정된 Tailwind 클래스는 `tailwindcss-preset-px-to-rem`가 잘 적용되었지만,
`w-${width}`와 같이 props로 받아와 동적으로 적용하는 클래스에는 적용되지 않음
![image](https://github.com/user-attachments/assets/feefc84e-ff13-4a96-9c56-2e681178475e)

<br/>

### 1-3. 원인
찾아보니 Tailwind는 클래스를 미리 정해둔 리스트에서 찾고 적용하는 방식인데,
`w-${width}`와 같이 동적인 Tailwind 클래스는 어떤 클래스가 사용될지 미리 예측할 수 없어 무시되는 경우가 많다고 합니다.

<br/>

### 결론
그래서 props로 받아온 px값을 rem 값으로 직접 계산해서 style에 적용하는 방식으로 구현했습니다.
![image](https://github.com/user-attachments/assets/8dcbe7d5-d2a7-4285-a406-9078497d7329)

---

## 🔊 전달 사항
Button 컴포넌트 사용 시 피그마에 나와 있는 수치 그대로 props로 전달해주시면 됩니다. (예시 파일 참고)