### PR TITLE
[feat/#71] 버튼 상태별 UI 변화 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,8 +11,7 @@
     "clsx",
     "import",
     "prettier",
-    "tailwindcss",
-    "lottie"
+    "tailwindcss"
   ],
   "extends": [
     "airbnb",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -67,7 +67,8 @@
     "react/prop-types": "off",
     "react/react-in-jsx-scope": "off",
     "react/require-default-props": "off",
-    "tailwindcss/classnames-order": "off"
+    "tailwindcss/classnames-order": "off",
+    "react/jsx-boolean-value": "off"
   },
   "parserOptions": {
     "sourceType": "module",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,5 +1,6 @@
 import {
   BUTTON_COLOR_PRESET,
+  BUTTON_STATUS_PRESET,
   BUTTON_TEXT_SIZE_PRESET,
 } from "@/src/constants/button";
 import ButtonProps from "@/src/types/button";
@@ -18,9 +19,9 @@ const Button = ({
   gap,
   backgroundColor,
   fontStyle = "xl",
-  onClick,
-  disabled = false,
   className,
+  disabled = false,
+  onClick,
   children,
 }: ButtonProps) => {
   // fullWidth 적용 시, height 미지정 경고 출력
@@ -34,6 +35,22 @@ const Button = ({
       }
     }
   }, [fullWidth, height]);
+
+  // text 여부 확인
+  const hasText = typeof children === "string";
+
+  // 버튼 상태에 따른 CSS 클래스
+  const stateClasses = clsx(
+    disabled
+      ? `${hasText ? "bg-gray-500 text-white" : backgroundColor && BUTTON_COLOR_PRESET[backgroundColor]} cursor-not-allowed`
+      : [
+          typeof BUTTON_STATUS_PRESET.hover === "function" &&
+            BUTTON_STATUS_PRESET.hover(backgroundColor),
+          typeof BUTTON_STATUS_PRESET.focus === "function" &&
+            BUTTON_STATUS_PRESET.focus(backgroundColor),
+          BUTTON_STATUS_PRESET.active,
+        ],
+  );
 
   return (
     <button
@@ -49,12 +66,12 @@ const Button = ({
         fullWidth && "w-full",
         backgroundColor && BUTTON_COLOR_PRESET[backgroundColor],
         fontStyle && BUTTON_TEXT_SIZE_PRESET[fontStyle],
-        disabled && "cursor-not-allowed",
+        stateClasses,
         className,
         "flex items-center justify-center",
       )}
-      onClick={onClick}
-      disabled={disabled}>
+      disabled={disabled}
+      onClick={onClick}>
       {children}
     </button>
   );

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -36,15 +36,11 @@ const Button = ({
     }
   }, [fullWidth, height]);
 
-  // text 여부 확인
-  const hasText = typeof children === "string";
-
   // 버튼 상태에 따른 CSS 클래스
   const stateClasses = clsx(
     disabled
-      ? hasText &&
-          typeof BUTTON_STATUS_PRESET.disabled === "function" &&
-          BUTTON_STATUS_PRESET.disabled(backgroundColor)
+      ? typeof BUTTON_STATUS_PRESET.disabled === "function" &&
+          BUTTON_STATUS_PRESET.disabled(backgroundColor, children)
       : [
           typeof BUTTON_STATUS_PRESET.hover === "function" &&
             BUTTON_STATUS_PRESET.hover(backgroundColor),

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -42,7 +42,9 @@ const Button = ({
   // 버튼 상태에 따른 CSS 클래스
   const stateClasses = clsx(
     disabled
-      ? `${hasText ? "bg-gray-500 text-white" : backgroundColor && BUTTON_COLOR_PRESET[backgroundColor]} cursor-not-allowed`
+      ? hasText &&
+          typeof BUTTON_STATUS_PRESET.disabled === "function" &&
+          BUTTON_STATUS_PRESET.disabled(backgroundColor)
       : [
           typeof BUTTON_STATUS_PRESET.hover === "function" &&
             BUTTON_STATUS_PRESET.hover(backgroundColor),

--- a/src/constants/button.ts
+++ b/src/constants/button.ts
@@ -2,15 +2,19 @@
  * @desc
  * Button 컴포넌트
  */
-import { ButtonColorType, ButtonTextSizeType } from "@/src/types/button";
+import {
+  ButtonColorType,
+  ButtonStatusType,
+  ButtonTextSizeType,
+} from "@/src/types/button";
 
 export const BUTTON_COLOR_PRESET: Record<ButtonColorType, string> = {
   white_black: "bg-white text-brand-500 border border-brand-500",
-  white_gray: "bg-white text-brand-400 border border-gray-200",
   white_green: "bg-white text-brand-400 border border-brand-400",
+  white_gray: "bg-white text-gray-500 border border-gray-200",
   black: "bg-brand-500 text-white border-none",
-  gray: "bg-gray-500 text-white border-none",
   green: "bg-brand-400 text-white border-none",
+  gray: "bg-gray-500 text-white border-none",
 };
 
 export const BUTTON_TEXT_SIZE_PRESET: Record<ButtonTextSizeType, string> = {
@@ -20,4 +24,42 @@ export const BUTTON_TEXT_SIZE_PRESET: Record<ButtonTextSizeType, string> = {
   xl: "text-16px-bold", // 16px 700 26px
   xxl: "text-18px-regular", // 18px 400 26px
   xxxl: "text-18px-medium", // 18px 500 26px
+};
+
+export const BUTTON_STATUS_PRESET: Record<
+  ButtonStatusType,
+  string | ((backgroundColor: ButtonColorType | undefined) => string)
+> = {
+  disabled: (backgroundColor: ButtonColorType | undefined) => {
+    return backgroundColor
+      ? `${BUTTON_COLOR_PRESET[backgroundColor]} cursor-not-allowed`
+      : "bg-gray-500 text-white cursor-not-allowed";
+  },
+  hover: (backgroundColor: ButtonColorType | undefined) => {
+    const hoverClassMap: Record<ButtonColorType, string> = {
+      white_black: "hover:bg-brand-200 transition",
+      white_green: "hover:bg-brand-200 transition",
+      white_gray: "",
+      black: "hover:bg-brand-600 transition",
+      green: "hover:bg-brand-500 transition",
+      gray: "",
+    };
+    return backgroundColor ? hoverClassMap[backgroundColor] : "";
+  },
+  focus: (backgroundColor: ButtonColorType | undefined) => {
+    const focusClassMap: Record<ButtonColorType, string> = {
+      white_black:
+        "focus:outline-none focus:border-none focus:ring-2 focus:ring-brand-500",
+      white_green:
+        "focus:outline-none focus:border-none focus:ring-2 focus:ring-brand-500",
+      white_gray: "",
+      black:
+        "focus:outline-none focus:border-none focus:ring-2 focus:ring-basic-navy",
+      green:
+        "focus:outline-none focus:border-none focus:ring-2 focus:ring-basic-navy",
+      gray: "",
+    };
+    return backgroundColor ? focusClassMap[backgroundColor] : "";
+  },
+  active: "active:scale-95 active:opacity-80",
 };

--- a/src/constants/button.ts
+++ b/src/constants/button.ts
@@ -7,6 +7,7 @@ import {
   ButtonStatusType,
   ButtonTextSizeType,
 } from "@/src/types/button";
+import { ReactNode } from "react";
 
 export const BUTTON_COLOR_PRESET: Record<ButtonColorType, string> = {
   white_black: "bg-white text-brand-500 border border-brand-500",
@@ -28,12 +29,20 @@ export const BUTTON_TEXT_SIZE_PRESET: Record<ButtonTextSizeType, string> = {
 
 export const BUTTON_STATUS_PRESET: Record<
   ButtonStatusType,
-  string | ((backgroundColor: ButtonColorType | undefined) => string)
+  | string
+  | ((
+      backgroundColor: ButtonColorType | undefined,
+      children?: ReactNode,
+    ) => string)
 > = {
-  disabled: (backgroundColor: ButtonColorType | undefined) => {
-    return backgroundColor
-      ? `${BUTTON_COLOR_PRESET[backgroundColor]} cursor-not-allowed`
-      : "bg-gray-500 text-white cursor-not-allowed";
+  disabled: (
+    backgroundColor: ButtonColorType | undefined,
+    children: ReactNode,
+  ) => {
+    const hasText = typeof children === "string";
+    return hasText && !backgroundColor
+      ? `bg-gray-500 text-white cursor-not-allowed`
+      : `${BUTTON_COLOR_PRESET[backgroundColor as ButtonColorType]} cursor-not-allowed`;
   },
   hover: (backgroundColor: ButtonColorType | undefined) => {
     const hoverClassMap: Record<ButtonColorType, string> = {

--- a/src/pages/button/index.tsx
+++ b/src/pages/button/index.tsx
@@ -118,7 +118,7 @@ const button = () => {
             gap="10"
             backgroundColor="white_gray"
             disabled={true}>
-            <AltArrowLeft width={21} height={21} className="text-gray" />
+            <AltArrowLeft width={21} height={21} />
           </Button>
           <Button
             type="button"

--- a/src/pages/button/index.tsx
+++ b/src/pages/button/index.tsx
@@ -15,9 +15,8 @@ const button = () => {
           fullWidth
           radius="6"
           gap="10"
-          backgroundColor="gray"
           fontStyle="xl"
-          disabled>
+          disabled={true}>
           로그인 하기
         </Button>
         <Button
@@ -118,8 +117,8 @@ const button = () => {
             radius="15"
             gap="10"
             backgroundColor="white_gray"
-            disabled>
-            <AltArrowLeft width={21} height={21} />
+            disabled={true}>
+            <AltArrowLeft width={21} height={21} className="text-gray" />
           </Button>
           <Button
             type="button"
@@ -141,7 +140,7 @@ const button = () => {
             fontStyle="xxl">
             2
           </Button>
-          <Button type="button" width="44" height="44">
+          <Button type="button" width="44" height="44" disabled={true}>
             <BtnArrow48pxDefault width={44} height={44} />
           </Button>
           <Button type="button" width="44" height="44">
@@ -184,9 +183,8 @@ const button = () => {
             height="56"
             radius="4"
             gap="4"
-            backgroundColor="gray"
             fontStyle="xl"
-            disabled>
+            disabled={true}>
             예약하기
           </Button>
           <Button

--- a/src/pages/button/index.tsx
+++ b/src/pages/button/index.tsx
@@ -6,7 +6,7 @@ import Button from "@/src/components/Button/Button";
 
 const button = () => {
   return (
-    <div className="flex flex-col gap-16 px-16 py-16">
+    <div className="flex flex-col gap-16 p-16">
       <p className="text-16px-semibold">🔻 로그인, 회원가입 페이지</p>
       <div className="flex flex-col gap-4">
         <Button

--- a/src/types/button.ts
+++ b/src/types/button.ts
@@ -1,3 +1,5 @@
+import { ReactNode } from "react";
+
 export type ButtonColorType =
   | "white_black"
   | "white_green"
@@ -8,6 +10,8 @@ export type ButtonColorType =
 
 export type ButtonTextSizeType = "s" | "m" | "l" | "xl" | "xxl" | "xxxl";
 
+export type ButtonStatusType = "disabled" | "hover" | "focus" | "active";
+
 interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   type: "button" | "submit" | "reset";
   width?: string;
@@ -17,9 +21,10 @@ interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   gap?: "4" | "8" | "10";
   backgroundColor?: ButtonColorType;
   fontStyle?: ButtonTextSizeType;
-  onClick?: () => void;
-  disabled?: boolean;
   className?: string;
+  disabled?: boolean;
+  onClick?: () => void;
+  children?: ReactNode;
 }
 
 export default ButtonProps;


### PR DESCRIPTION
# Resolved: #71 

## 🔨 작업내역
- 요청사항에 따른 버튼 상태별 UI 변화 구현
  - `disabled`
     - **children에 텍스트 포함 시**: 회색 배경, 흰색 텍스트, `cursor-not-allowed` 적용
     - **children에 아이콘 포함 시(children에 텍스트 포함X)**: 버튼의 `backgroundColor` 유지, `cursor-not-allowed` 적용
  - `:hover`
     - **`backgroundColor`가 있을 경우**: 버튼 색상 별 배경색 + `transition` 적용
     - **`backgroundColor`가 없을 경우 + `backgroundColor`가 gray 또는 white_gray일 경우**: `hover` 적용X
  - `:focus`
     - **`backgroundColor`가 있을 경우**: 버튼 색상 별 `ring` + outline-none, border-none 적용
     - **`backgroundColor`가 없을 경우 + `backgroundColor`가 gray 또는 white_gray일 경우**: `focus` 적용X
  - `:active`
     - 요소 크기 95%로 축소, 불투명도 80%로 감소

<br/>

## 👩‍🔧 오류내역
1. **eslint-plugin-lottie** (✅ 해결 완료)
    ![image](https://github.com/user-attachments/assets/33a6370c-82b1-4d8c-b3f1-f5f487a6219b)
   - 요청자: @JuhyeokC 
   - 해결 방법: `.eslintrc.json` plugins에서 lottie 제거

<br/>

2. **ESLint 경고1** (✅ 해결 완료)
   - 경고 내용
    ![image](https://github.com/user-attachments/assets/40df2a8f-2abb-4274-aa06-ff19f42586c9)
    Button 예시파일에서 `disabled={true}`와 같이 boolean 속성에 값을 명시했을 때 ESLint 경고 발생
      ```
      Value must be omitted for boolean attribute disabled 오류
      ```
   - 해결 방법
    이 경고를 해결하려면 disabled 속성에는 값을 생략하고 `disabled`만 작성해야 하는데
    disabled 속성을 고정하면 동적으로 상태를 변경할 수 없으므로
    `.eslintrc.json`에서 `react/jsx-boolean-value` 규칙을 비활성화하였습니다.
      ```
      "react/jsx-boolean-value": "off"
      ```  
    - 규칙 설명: `react/jsx-boolean-value`
      JSX에서 disabled와 같은 boolean 속성을 사용할 때 `disabled={true}` 대신 disabled만 쓰도록 권장하는 규칙입니다.
      이 규칙을 "off"로 설정하면 `react/jsx-boolean-value` 규칙이 비활성화되어, `disabled={true}`처럼 작성하더라도 경고나 오류 메시지가 표시되지 않습니다.
      이 설정을 추가한 후에는 disabled 속성을 페이지에서 동적으로 제어할 수 있으면서도, ESLint 경고를 피할 수 있습니다.

<br/>

3. **ESLint 경고2** (✅ 해결 완료)
   - 경고 내용
    ![image](https://github.com/user-attachments/assets/2c5c6c1c-f39a-42a5-a3c2-262ce0216bac)
   - 해결 방법: `text-gray` 삭제

<br/>

## 🎨 예시이미지
- ❌포인터의 노란 원 효과는 포함❌
  ![1102_buttonStatus](https://github.com/user-attachments/assets/09322fd7-ca45-4708-98b3-d40a745d7d55)
