### PR TITLE
[fix/#77] 폰트 스타일명(text->font) 수정

### DIFF
--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -27,7 +27,7 @@ const Avatar = () => {
       ) : (
         <IconUser className="text-brand-600" />
       )}
-      <p className="text-16px-medium text-brand-600">{userData.nickname}</p>
+      <p className="font-16px-medium text-brand-600">{userData.nickname}</p>
     </article>
   );
 };

--- a/src/components/OauthSign/index.tsx
+++ b/src/components/OauthSign/index.tsx
@@ -6,7 +6,7 @@ const OauthSign = ({ action }: OauthSignProps) => {
     <div className="mt-48">
       <div className="flex items-center gap-36">
         <i className="h-1 w-full bg-gray-200" />
-        <p className="text-20px-regular text-nowrap text-gray-700">
+        <p className="font-20px-regular text-nowrap text-gray-700">
           SNS 계정으로 {action === "in" ? "로그인" : "회원가입"}하기
         </p>
         <i className="h-1 w-full bg-gray-200" />

--- a/src/components/SignMenu/index.tsx
+++ b/src/components/SignMenu/index.tsx
@@ -2,7 +2,7 @@ import PATH_NAMES from "@/src/constants/pathname";
 import Link from "next/link";
 
 const CLASS_NAME = {
-  text: "text-16px-medium text-basic-black text-nowrap",
+  text: "font-16px-medium text-basic-black text-nowrap",
 };
 
 const SignMenu = () => {

--- a/src/components/TestPages/index.tsx
+++ b/src/components/TestPages/index.tsx
@@ -14,7 +14,7 @@ const TestPages = () => {
 
   return (
     <Dropdown>
-      <Dropdown.Trigger className="text-16px-medium text-nowrap text-white">
+      <Dropdown.Trigger className="font-16px-medium text-nowrap text-white">
         테스트 페이지 바로가기
       </Dropdown.Trigger>
       <Dropdown.Menu className="!top-auto bottom-full mb-4 mt-0">

--- a/src/constants/button.ts
+++ b/src/constants/button.ts
@@ -19,12 +19,12 @@ export const BUTTON_COLOR_PRESET: Record<ButtonColorType, string> = {
 };
 
 export const BUTTON_TEXT_SIZE_PRESET: Record<ButtonTextSizeType, string> = {
-  s: "text-14px-medium", // 14px 500 24px
-  m: "text-14px-bold", // 14px 700 24px
-  l: "text-16px-medium", // 16px 500 26px
-  xl: "text-16px-bold", // 16px 700 26px
-  xxl: "text-18px-regular", // 18px 400 26px
-  xxxl: "text-18px-medium", // 18px 500 26px
+  s: "font-14px-medium", // 14px 500 24px
+  m: "font-14px-bold", // 14px 700 24px
+  l: "font-16px-medium", // 16px 500 26px
+  xl: "font-16px-bold", // 16px 700 26px
+  xxl: "font-18px-regular", // 18px 400 26px
+  xxxl: "font-18px-medium", // 18px 500 26px
 };
 
 export const BUTTON_STATUS_PRESET: Record<

--- a/src/containers/Footer/index.tsx
+++ b/src/containers/Footer/index.tsx
@@ -30,12 +30,12 @@ const SNS_LINKS = [
 ];
 
 const CLASS_NAME = {
-  text: "text-16px-medium text-white text-nowrap",
+  text: "font-16px-medium text-white text-nowrap",
 };
 
 const Footer = () => {
   return (
-    <footer className="bg-brand-500 -mx-32 h-footer p-32">
+    <footer className="-mx-32 h-footer bg-brand-500 p-32">
       <div className="mx-auto flex h-full max-w-screen-xl flex-wrap items-start justify-between gap-32">
         <div className="flex items-center">
           <p className={CLASS_NAME.text}>©vivitrip - 2024</p>

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -26,17 +26,17 @@ const Custom404: NextPage<{ statusCode: number }> = () => {
     radius: "8",
     gap: "4",
     fontStyle: "l",
-    className: "bg-basic-navy text-white lg:!h-48 lg:text-18px-medium",
+    className: "bg-basic-navy text-white lg:!h-48 lg:font-18px-medium",
   };
 
   return (
     <div className="flex h-screen flex-col items-center justify-center">
       <div className="flex w-350 flex-col gap-24 text-center lg:w-440 lg:gap-30">
         <Lottie loop animationData={lottieJson} play />
-        <h1 className="text-24px-bold text-basic-navy lg:text-28px-bold">
+        <h1 className="font-24px-bold lg:font-28px-bold text-basic-navy">
           페이지를 찾을 수 없습니다.
         </h1>
-        <h5 className="text-16px-regular lg:text-18px-regular text-gray-800">
+        <h5 className="font-16px-regular lg:font-18px-regular text-gray-800">
           페이지가 존재하지 않거나 사용할 수 없는 페이지입니다. <br />
           입력하신 주소가 정확한지 다시 한 번 확인해주세요.
         </h5>

--- a/src/pages/button/index.tsx
+++ b/src/pages/button/index.tsx
@@ -7,7 +7,7 @@ import Button from "@/src/components/Button/Button";
 const button = () => {
   return (
     <div className="flex flex-col gap-16 p-16">
-      <p className="text-16px-semibold">🔻 로그인, 회원가입 페이지</p>
+      <p className="font-16px-semibold">🔻 로그인, 회원가입 페이지</p>
       <div className="flex flex-col gap-4">
         <Button
           type="submit"
@@ -40,7 +40,7 @@ const button = () => {
           로그인 하기
         </Button>
       </div>
-      <p className="text-16px-semibold">🔻 로그인, 회원가입 페이지_팝업</p>
+      <p className="font-16px-semibold">🔻 로그인, 회원가입 페이지_팝업</p>
       <div className="flex gap-4">
         <Button
           type="button"
@@ -63,7 +63,7 @@ const button = () => {
           확인
         </Button>
       </div>
-      <p className="text-16px-semibold">🔻 메인화면</p>
+      <p className="font-16px-semibold">🔻 메인화면</p>
       <div className="flex flex-col gap-4">
         <div className="flex gap-4">
           <Button
@@ -152,7 +152,7 @@ const button = () => {
           </Button>
         </div>
       </div>
-      <p className="text-16px-semibold">🔻 체험 상세</p>
+      <p className="font-16px-semibold">🔻 체험 상세</p>
       <div className="flex flex-col gap-4">
         <div className="flex gap-4">
           <Button
@@ -233,7 +233,7 @@ const button = () => {
           </Button>
         </div>
       </div>
-      <p className="text-16px-semibold">🔻 내 정보</p>
+      <p className="font-16px-semibold">🔻 내 정보</p>
       <div className="flex gap-4">
         <Button
           type="submit"
@@ -246,7 +246,7 @@ const button = () => {
           저장하기
         </Button>
       </div>
-      <p className="text-16px-semibold">🔻 예약 내역</p>
+      <p className="font-16px-semibold">🔻 예약 내역</p>
       <div className="flex gap-4">
         <Button
           type="button"
@@ -289,7 +289,7 @@ const button = () => {
           취소하기
         </Button>
       </div>
-      <p className="text-16px-semibold">🔻 예약 내역</p>
+      <p className="font-16px-semibold">🔻 예약 내역</p>
       <div className="flex gap-4">
         <Button
           type="button"
@@ -302,7 +302,7 @@ const button = () => {
           후기 작성
         </Button>
       </div>
-      <p className="text-16px-semibold">
+      <p className="font-16px-semibold">
         🔻 체험 관리, 체험 등록, 내 체험 수정
       </p>
       <div className="flex gap-4">
@@ -337,7 +337,7 @@ const button = () => {
           수정하기
         </Button>
       </div>
-      <p className="text-16px-semibold">🔻 예약 정보</p>
+      <p className="font-16px-semibold">🔻 예약 정보</p>
       <div className="flex gap-4">
         <Button
           type="button"
@@ -360,7 +360,7 @@ const button = () => {
           거절하기
         </Button>
       </div>
-      <p className="text-16px-semibold">🔻 알림</p>
+      <p className="font-16px-semibold">🔻 알림</p>
       <div className="flex gap-4">
         <form className="flex gap-4">
           <input type="text" className="border" />

--- a/src/pages/sign-in/index.tsx
+++ b/src/pages/sign-in/index.tsx
@@ -34,26 +34,26 @@ const SignIn = () => {
       <form className="mt-56 flex flex-col gap-32" onSubmit={handleSignIn}>
         <div className="relative">
           <label htmlFor="login_id" className="flex flex-col gap-8">
-            <p className="text-16px-regular text-basic-black">이메일</p>
+            <p className="font-16px-regular text-basic-black">이메일</p>
             <input
               type="email"
               name="email"
               id="login_email"
               placeholder="이메일을 입력해 주세요"
-              className="text-16px-regular min-h-56 rounded-6 border border-gray-500 px-20 py-12 outline-none transition-all focus:border-brand-400"
+              className="font-16px-regular min-h-56 rounded-6 border border-gray-500 px-20 py-12 outline-none transition-all focus:border-brand-400"
             />
           </label>
         </div>
 
         <div className="relative">
           <label htmlFor="login_pw" className="flex flex-col gap-8">
-            <p className="text-16px-regular text-basic-black">비밀번호</p>
+            <p className="font-16px-regular text-basic-black">비밀번호</p>
             <input
               type="password"
               name="password"
               id="login_password"
               placeholder="비밀번호을 입력해 주세요"
-              className="text-16px-regular min-h-56 rounded-6 border border-gray-500 px-20 py-12 outline-none transition-all focus:border-brand-400"
+              className="font-16px-regular min-h-56 rounded-6 border border-gray-500 px-20 py-12 outline-none transition-all focus:border-brand-400"
             />
           </label>
         </div>
@@ -74,7 +74,7 @@ const SignIn = () => {
       </form>
 
       <p className="mt-32 text-center">
-        <span className="text-16px-regular text-gray-800">
+        <span className="font-16px-regular text-gray-800">
           회원이 아니신가요?
         </span>
         <Link

--- a/src/pages/sign-up/index.tsx
+++ b/src/pages/sign-up/index.tsx
@@ -39,13 +39,13 @@ const SignUp = () => {
       <form className="mt-56 flex flex-col gap-32" onSubmit={handleSignUp}>
         <div className="relative">
           <label htmlFor="signup_email" className="flex flex-col gap-8">
-            <p className="text-16px-regular text-basic-black">이메일</p>
+            <p className="font-16px-regular text-basic-black">이메일</p>
             <input
               type="email"
               name="email"
               id="signup_email"
               placeholder="이메일을 입력해 주세요"
-              className="text-16px-regular min-h-56 rounded-6 border border-gray-500 px-20 py-12 outline-none transition-all focus:border-brand-400"
+              className="font-16px-regular min-h-56 rounded-6 border border-gray-500 px-20 py-12 outline-none transition-all focus:border-brand-400"
               defaultValue={email}
             />
           </label>
@@ -53,26 +53,26 @@ const SignUp = () => {
 
         <div className="relative">
           <label htmlFor="signup_nickname" className="flex flex-col gap-8">
-            <p className="text-16px-regular text-basic-black">닉네임</p>
+            <p className="font-16px-regular text-basic-black">닉네임</p>
             <input
               type="text"
               name="nickname"
               id="signup_nickname"
               placeholder="닉네임을 입력해 주세요"
-              className="text-16px-regular min-h-56 rounded-6 border border-gray-500 px-20 py-12 outline-none transition-all focus:border-brand-400"
+              className="font-16px-regular min-h-56 rounded-6 border border-gray-500 px-20 py-12 outline-none transition-all focus:border-brand-400"
             />
           </label>
         </div>
 
         <div className="relative">
           <label htmlFor="signup_password" className="flex flex-col gap-8">
-            <p className="text-16px-regular text-basic-black">비밀번호</p>
+            <p className="font-16px-regular text-basic-black">비밀번호</p>
             <input
               type="password"
               name="password"
               id="signup_password"
               placeholder="비밀번호을 입력해 주세요"
-              className="text-16px-regular min-h-56 rounded-6 border border-gray-500 px-20 py-12 outline-none transition-all focus:border-brand-400"
+              className="font-16px-regular min-h-56 rounded-6 border border-gray-500 px-20 py-12 outline-none transition-all focus:border-brand-400"
             />
           </label>
         </div>
@@ -81,13 +81,13 @@ const SignUp = () => {
           <label
             htmlFor="signup_confirmPassword"
             className="flex flex-col gap-8">
-            <p className="text-16px-regular text-basic-black">비밀번호 확인</p>
+            <p className="font-16px-regular text-basic-black">비밀번호 확인</p>
             <input
               type="password"
               name="confirmPassword"
               id="signup_confirmPassword"
               placeholder="비밀번호를 한번 더 입력해 주세요"
-              className="text-16px-regular min-h-56 rounded-6 border border-gray-500 px-20 py-12 outline-none transition-all focus:border-brand-400"
+              className="font-16px-regular min-h-56 rounded-6 border border-gray-500 px-20 py-12 outline-none transition-all focus:border-brand-400"
             />
           </label>
         </div>
@@ -108,7 +108,7 @@ const SignUp = () => {
       </form>
 
       <p className="mt-32 text-center">
-        <span className="text-16px-regular text-gray-800">회원이신가요?</span>
+        <span className="font-16px-regular text-gray-800">회원이신가요?</span>
         <Link
           href={PATH_NAMES.SignIn}
           className="ml-8 text-brand-500 underline underline-offset-2">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -68,6 +68,11 @@
     @apply text-[32px] font-semibold leading-[42px];
   }
 
+  /* Text-2.5xl */
+  .font-28px-bold {
+    @apply text-[28px] font-bold leading-[32px];
+  }
+
   /* Text-2xl */
   .font-24px-bold {
     @apply text-[24px] font-bold leading-[32px];

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -60,123 +60,118 @@
 
 @layer utilities {
   /* Text-3xl */
-  .text-32px-bold {
+  .font-32px-bold {
     @apply text-[32px] font-bold leading-[42px];
   }
 
-  .text-32px-semibold {
+  .font-32px-semibold {
     @apply text-[32px] font-semibold leading-[42px];
   }
 
-  /* Text-2.5xl */
-  .text-28px-bold {
-    @apply text-[28px] font-bold leading-[32px];
-  }
-
   /* Text-2xl */
-  .text-24px-bold {
+  .font-24px-bold {
     @apply text-[24px] font-bold leading-[32px];
   }
 
-  .text-24px-semibold {
+  .font-24px-semibold {
     @apply text-[24px] font-semibold leading-[32px];
   }
 
-  .text-24px-medium {
+  .font-24px-medium {
     @apply text-[24px] font-medium leading-[32px];
   }
 
-  .text-24px-regular {
+  .font-24px-regular {
     @apply text-[24px] font-normal leading-[32px];
   }
 
   /* Text-xl */
-  .text-20px-bold {
+  .font-20px-bold {
     @apply text-[20px] font-bold leading-[32px];
   }
 
-  .text-20px-semibold {
+  .font-20px-semibold {
     @apply text-[20px] font-semibold leading-[32px];
   }
 
-  .text-20px-medium {
+  .font-20px-medium {
     @apply text-[20px] font-medium leading-[32px];
   }
 
-  .text-20px-regular {
+  .font-20px-regular {
     @apply text-[20px] font-normal leading-[32px];
   }
 
   /* Text-2lg */
-  .text-18px-bold {
+  .font-18px-bold {
     @apply text-[18px] font-bold leading-[26px];
   }
 
-  .text-18px-semibold {
+  .font-18px-semibold {
     @apply text-[18px] font-semibold leading-[26px];
   }
 
-  .text-18px-medium {
+  .font-18px-medium {
     @apply text-[18px] font-medium leading-[26px];
   }
 
-  .text-18px-regular {
+  .font-18px-regular {
     @apply text-[18px] font-normal leading-[26px];
   }
 
   /* Text-lg */
-  .text-16px-bold {
+  .font-16px-bold {
     @apply text-[16px] font-bold leading-[26px];
   }
 
-  .text-16px-semibold {
+  .font-16px-semibold {
     @apply text-[16px] font-semibold leading-[26px];
   }
 
-  .text-16px-medium {
+  .font-16px-medium {
     @apply text-[16px] font-medium leading-[26px];
   }
 
-  .text-16px-regular {
+  .font-16px-regular {
     @apply text-[16px] font-normal leading-[26px];
   }
 
   /* Text-md */
-  .text-14px-bold {
+  .font-14px-bold {
     @apply text-[14px] font-bold leading-[24px];
   }
 
-  .text-14px-semibold {
+  .font-14px-semibold {
     @apply text-[14px] font-semibold leading-[24px];
   }
 
-  .text-14px-medium {
+  .font-14px-medium {
     @apply text-[14px] font-medium leading-[24px];
   }
 
-  .text-14px-regular {
+  .font-14px-regular {
     @apply text-[14px] font-normal leading-[24px];
   }
 
   /* Text-sm */
-  .text-13px-semibold {
+  .font-13px-semibold {
     @apply text-[13px] font-semibold leading-[22px];
   }
 
-  .text-13px-medium {
+  .font-13px-medium {
     @apply text-[13px] font-medium leading-[22px];
   }
 
   /* Text-xs */
-  .text-12px-semibold {
+  .font-12px-semibold {
     @apply text-[12px] font-semibold leading-[18px];
   }
 
-  .text-12px-medium {
+  .font-12px-medium {
     @apply text-[12px] font-medium leading-[18px];
   }
 
-  .text-12px-regular {
+  .font-12px-regular {
     @apply text-[12px] font-normal leading-[18px];
   }
 }


### PR DESCRIPTION
# Resolved: #77

## 🔨 작업내역

-  폰트 스타일명(text->font) 수정

- [이유] : tailwind-merge 가 text- 처럼 같은 블록으로 시작할 경우에 가장 마지막에 선언되어있는 클래스로 사용되어 먼저 선언된 클래스가 무시됨(주혁님이 발견)

- [처리] : globals.css에서 설정된 폰트 스타일을 예시 text-24px-bold 에서 font-24px-bold 로 수정

## 🔊 전달사항

- 

## 📌 이슈사항

- 

## 👩‍🔧 오류내역

- 

## 🎨 예시이미지

- 
