### PR TITLE
[feat/#122] 알림 기능 구현

### DIFF
--- a/assets/svgs/ic_refresh.svg
+++ b/assets/svgs/ic_refresh.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="800px" height="800px" viewBox="0 0 512 512"
+  xmlns="http://www.w3.org/2000/svg">
+  <path d="M320,146s24.36-12-64-12A160,160,0,1,0,416,294" fill="none" stroke="currentColor" stroke-linecap="round" stroke-miterlimit="10" stroke-width="32px"/>
+  <polyline points="256 58 336 138 256 218" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32px"/>
+</svg>

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -45,7 +45,9 @@ const Avatar = () => {
       ) : (
         <IconUser className="text-brand-600" />
       )}
-      <p className="font-16px-medium text-brand-600">{userData.nickname}</p>
+      <p className="font-16px-medium hidden text-brand-600 md:block">
+        {userData.nickname}
+      </p>
     </article>
   );
 };

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -135,7 +135,7 @@ Dropdown.Close = ({
 
   return (
     <button
-      className={clsx("relative block w-full rounded-none", className)}
+      className={clsx("relative block rounded-none", className)}
       type="button"
       onMouseDown={(event: MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();

--- a/src/components/HighlightText/HighlightText.tsx
+++ b/src/components/HighlightText/HighlightText.tsx
@@ -1,0 +1,38 @@
+import clsx from "clsx";
+
+interface HighlightProps {
+  className?: string;
+  text: string;
+  keywords: Record<string, string>; // 키워드와 색상 매핑
+}
+
+const HighlightText = ({
+  className,
+  text,
+  keywords,
+  ...rest
+}: HighlightProps) => {
+  const parts = text.split(
+    new RegExp(`(${Object.keys(keywords).join("|")})`, "g"),
+  );
+
+  return (
+    <p className={className} {...rest}>
+      {parts.map((part) => {
+        const cn = keywords[part];
+        return cn ? (
+          <span
+            key={`highlight-text-${part}`}
+            // eslint-disable-next-line tailwindcss/no-custom-classname
+            className={clsx(`text-${cn}`, "font-semibold")}>
+            {part}
+          </span>
+        ) : (
+          part
+        );
+      })}
+    </p>
+  );
+};
+
+export default HighlightText;

--- a/src/components/Notification/index.tsx
+++ b/src/components/Notification/index.tsx
@@ -1,25 +1,150 @@
+import IconClose from "@/assets/svgs/close.svg";
 import IconNotification from "@/assets/svgs/ic_notification.svg";
+import IconRefresh from "@/assets/svgs/ic_refresh.svg";
 import Dropdown from "@/src/components/Dropdown";
 import NotificationItem from "@/src/components/NotificationItem";
+import {
+  useDeleteMyNotification,
+  useMyNotificationsListQuery,
+} from "@/src/queries/my-notifications";
+import type {
+  MyNotificationsProps,
+  NotificationId,
+} from "@/src/types/my-notifications";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * @description 알림 목데이터
+ */
+const MOCK_DATA: MyNotificationsProps[] = [
+  {
+    id: 1001,
+    teamId: "팀 아이디 1",
+    userId: 1002,
+    content: "체험명(2023-01-14 15:00~18:00) 예약이 승인되었어요.",
+    createdAt: "2025-01-13T14:00:00",
+    updatedAt: "2025-01-13T16:30:00",
+    deletedAt: "2025-01-13T18:00:00",
+  },
+  {
+    id: 2001,
+    teamId: "팀 아이디 2",
+    userId: 2002,
+    content: "체험명(2023-01-14 15:00~18:00) 예약이 거절되었어요.",
+    createdAt: "2025-01-14T14:00:00",
+    updatedAt: "2025-01-14T16:30:00",
+    deletedAt: "2025-01-14T18:00:00",
+  },
+  {
+    id: 3001,
+    teamId: "팀 아이디 3",
+    userId: 3002,
+    content: "체험명(2023-01-14 15:00~18:00) 예약이 새로 들어왔어요.",
+    createdAt: "2025-01-15T14:00:00",
+    updatedAt: "2025-01-15T16:30:00",
+    deletedAt: "2025-01-15T18:00:00",
+  },
+];
 
 const Notification = () => {
+  const router = useRouter();
+  const size: number = 10;
+  const [cursorId, setCursorId] = useState<number | null>(null);
+  const [totalCount, setTotalCount] = useState<number>(0);
+  const [items, setItems] = useState<MyNotificationsProps[]>([]);
+  const { data, isPending, refetch } = useMyNotificationsListQuery({
+    size,
+    cursorId,
+  });
+  const { mutate: deleteNotification } = useDeleteMyNotification();
+
+  const handleDeleteItem = async (id: NotificationId) => {
+    console.log("🚀 ~ handleDeleteItem ~ id:", id);
+    /**
+     * @todo
+     * 알림 삭제 함수 실행
+     */
+    const response = await deleteNotification({ notificationId: id });
+    console.log("🚀 ~ handleDeleteItem ~ response:", response);
+
+    setItems((prev) => {
+      return prev.filter((item) => item.id !== id);
+    });
+  };
+
   /**
    * @todo
-   * 알람 여부에 따라 인디케이터 출력
+   * 실제 알림 데이터로 구현 시 수정해야함.
    */
-  const Indicator = false;
+  useEffect(() => {
+    setTotalCount(items.length);
+  }, [items]);
+
+  const handleIndicator = useCallback(() => {
+    if (data) {
+      setCursorId(data.data.cursorId);
+      setTotalCount(MOCK_DATA.length);
+      // setTotalCount(data.data.totalCount);
+      // setItems(data.data.notifications);
+      setItems(MOCK_DATA);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+
+  useEffect(() => {
+    handleIndicator();
+  }, [handleIndicator]);
+
+  useEffect(() => {
+    console.log("🚀 ~ Notification ~ router:", router);
+  }, [router]);
 
   return (
-    <Dropdown sustain>
+    <Dropdown sustain key={router.asPath}>
       <Dropdown.Trigger>
-        {Indicator && (
+        {totalCount > 0 && (
           <i className="absolute right-0 top-0 z-10 size-8 -translate-x-2 -translate-y-2 rounded-full border border-white bg-red-200" />
         )}
         <IconNotification className="text-gray-600" />
       </Dropdown.Trigger>
-      <Dropdown.Menu className="left-auto right-0 w-fit">
-        <Dropdown.Close>X</Dropdown.Close>
-        <NotificationItem />
+
+      <Dropdown.Menu className="left-auto right-0 w-fit !border-gray-200 shadow-xl">
+        <div className="fixed z-50 flex flex-col bg-brand-200 md:relative md:min-w-320">
+          <div className="flex items-center justify-between p-16 pb-8 text-brand-600 last:pb-16">
+            <div className="flex items-center justify-start gap-8">
+              <p className="font-20px-bold text-nowrap">
+                {totalCount > 0 ? `알림 ${totalCount}개` : `알림이 없습니다.`}
+              </p>
+              <button
+                type="button"
+                aria-label="새로고침"
+                onClick={() => refetch()}
+                disabled={isPending}>
+                <IconRefresh className="size-16" />
+              </button>
+            </div>
+            <Dropdown.Close>
+              <IconClose />
+            </Dropdown.Close>
+          </div>
+
+          {items && items.length > 0 && (
+            <div className="flex flex-col gap-8 overflow-auto p-16 pb-24 pt-8 md:max-h-320">
+              {items.map((item) => {
+                return (
+                  <NotificationItem
+                    key={`MyNotifications_${item.id}`}
+                    item={item}
+                    handleDelete={() => {
+                      handleDeleteItem(item.id);
+                    }}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </div>
       </Dropdown.Menu>
     </Dropdown>
   );

--- a/src/components/Notification/index.tsx
+++ b/src/components/Notification/index.tsx
@@ -106,12 +106,12 @@ const Notification = () => {
         {totalCount > 0 && (
           <i className="absolute right-0 top-0 z-10 size-8 -translate-x-2 -translate-y-2 rounded-full border border-white bg-red-200" />
         )}
-        <IconNotification className="text-gray-600" />
+        <IconNotification className="text-gray-600 focus:outline-none" />
       </Dropdown.Trigger>
 
       <Dropdown.Menu className="left-auto right-0 w-fit !border-gray-200 shadow-xl">
-        <div className="fixed z-50 flex flex-col bg-brand-200 md:relative md:min-w-320">
-          <div className="flex items-center justify-between p-16 pb-8 text-brand-600 last:pb-16">
+        <div className="fixed inset-0 z-50 flex flex-col bg-brand-200 md:relative md:inset-auto md:min-w-320">
+          <div className="flex h-header items-center justify-between p-24 pb-16 text-brand-600 last:pb-16 md:h-auto md:p-16 md:pb-8">
             <div className="flex items-center justify-start gap-8">
               <p className="font-20px-bold text-nowrap">
                 {totalCount > 0 ? `알림 ${totalCount}개` : `알림이 없습니다.`}
@@ -130,7 +130,7 @@ const Notification = () => {
           </div>
 
           {items && items.length > 0 && (
-            <div className="flex flex-col gap-8 overflow-auto p-16 pb-24 pt-8 md:max-h-320">
+            <div className="flex h-main flex-col gap-8 overflow-auto p-24 pt-8 md:h-320 md:!max-h-[50vh] md:p-16 md:pb-24 md:pt-8">
               {items.map((item) => {
                 return (
                   <NotificationItem

--- a/src/components/NotificationItem/index.tsx
+++ b/src/components/NotificationItem/index.tsx
@@ -1,8 +1,78 @@
-const NotificationItem = () => {
+import IconClose from "@/assets/svgs/close.svg";
+import HighlightText from "@/src/components/HighlightText/HighlightText";
+import STATUS_KEYWORD_HIGHLIGHT from "@/src/constants/my-notifications";
+import type { MyNotificationsProps } from "@/src/types/my-notifications";
+import { getTimeDiffText } from "@/src/utils/date";
+import clsx from "clsx";
+import Link from "next/link";
+import { MouseEvent, useMemo } from "react";
+
+const NotificationItem = ({
+  item,
+  handleDelete,
+}: {
+  item: MyNotificationsProps;
+  handleDelete: () => void;
+}) => {
+  /**
+   * @todo
+   * 1.
+   * swagger 에서 응답 객체에는 { id, teamId, userId, content, createdAt, updatedAt, deletedAt } 7가지가 전부이다.
+   * 예약 상태에는 [ pending, confirmed, declined, canceled, completed ] 5가지가 있다.
+   * 실제 데이터를 확인하여 예약상태를 구현할 것.
+   *
+   * 2.
+   * 알람을 클릭하면 마이페이지의 예약 내역(승인|거절), 예약 현황(새로 들어왔어요.) 으로 이동하는 링크 구현
+   */
+  const statusColor = useMemo<string | null>(() => {
+    if (item.content.includes("승인")) {
+      return `bg-${STATUS_KEYWORD_HIGHLIGHT["승인"]}`;
+    }
+
+    if (item.content.includes("거절")) {
+      return `bg-${STATUS_KEYWORD_HIGHLIGHT["거절"]}`;
+    }
+
+    if (item.content.includes("새로 들어왔어요.")) {
+      return `bg-${STATUS_KEYWORD_HIGHLIGHT["새로 들어왔어요."]}`;
+    }
+
+    return null;
+  }, [item]);
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    handleDelete();
+  };
+
   return (
-    <div>
-      <p>NotificationItem</p>
-    </div>
+    <Link
+      href={
+        statusColor === null
+          ? ""
+          : statusColor.includes("green")
+            ? `/my-page`
+            : `/my-page`
+      }
+      className="flex flex-col items-stretch justify-center gap-4 rounded border border-brand-100 bg-white p-12 shadow-md">
+      <div className="flex items-center justify-between">
+        <p className={clsx(statusColor, "size-5 rounded-full")} />
+        <IconClose
+          className="origin-right scale-75 cursor-pointer text-gray-500"
+          onClick={handleClick}
+        />
+      </div>
+
+      <HighlightText
+        className="font-12px-regular"
+        text={item.content}
+        keywords={STATUS_KEYWORD_HIGHLIGHT}
+      />
+
+      <p className="font-12px-regular text-gray-700">
+        {getTimeDiffText(item.updatedAt)}
+      </p>
+    </Link>
   );
 };
 

--- a/src/components/UserMenu/index.tsx
+++ b/src/components/UserMenu/index.tsx
@@ -5,7 +5,7 @@ const UserMenu = () => {
   return (
     <div className="flex items-center justify-between">
       <Notification />
-      <hr className="mx-24 h-20 border-0 border-l border-gray-200" />
+      <hr className="mx-16 h-20 border-0 border-l border-gray-200 md:mx-24" />
       <UserProfile />
     </div>
   );

--- a/src/constants/my-notifications.ts
+++ b/src/constants/my-notifications.ts
@@ -1,0 +1,7 @@
+const STATUS_KEYWORD_HIGHLIGHT: Record<string, string> = {
+  승인: "blue-200",
+  거절: "red-200",
+  "새로 들어왔어요.": "green-200",
+};
+
+export default STATUS_KEYWORD_HIGHLIGHT;

--- a/src/containers/Footer/index.tsx
+++ b/src/containers/Footer/index.tsx
@@ -35,14 +35,14 @@ const CLASS_NAME = {
 
 const Footer = () => {
   return (
-    <footer className="-mx-32 h-footer bg-brand-500 p-32">
-      <div className="mx-auto flex h-full max-w-screen-xl flex-wrap items-start justify-between gap-32">
+    <footer className="-mx-24 h-footer bg-brand-500 p-32 md:-mx-32">
+      <div className="mx-auto flex h-full max-w-screen-xl flex-wrap items-start justify-between gap-x-12 gap-y-40 md:gap-x-32">
         <div className="flex items-center">
           <p className={CLASS_NAME.text}>©vivitrip - 2024</p>
-          <hr className="mx-24 h-16 border-0 border-l border-white opacity-50" />
+          <hr className="mx-12 h-16 border-0 border-l border-white opacity-50 md:mx-24" />
           <TestPages />
         </div>
-        <div className="flex items-center gap-32">
+        <div className="flex items-center gap-12 md:gap-32">
           <Link className={CLASS_NAME.text} href={PATH_NAMES.PrivacyPolicy}>
             Privacy Policy
           </Link>
@@ -50,7 +50,7 @@ const Footer = () => {
             FAQ
           </Link>
         </div>
-        <div className="flex items-center gap-16">
+        <div className="flex items-center gap-12 md:gap-16">
           {SNS_LINKS.map(({ name, icon, href }) => {
             return (
               <div key={`sns_link_${name}`}>

--- a/src/containers/GNB/index.tsx
+++ b/src/containers/GNB/index.tsx
@@ -18,7 +18,7 @@ const GNB = () => {
   const { userData } = useUserStore();
 
   return (
-    <header className="h-header w-full border-b border-solid border-gray-200 px-32 py-16">
+    <header className="h-header w-full border-b border-solid border-gray-200 p-24 lg:px-24">
       <div className="mx-auto flex h-full max-w-screen-xl justify-between">
         <Logo />
         {userData ? <UserMenu /> : <SignMenu />}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -47,7 +47,7 @@ const App = ({
       {is404Page ? null : <GNB />}
       <main
         className={clsx(
-          "overflow-auto px-32",
+          "overflow-auto px-24 md:px-32",
           is404Page ? "bg-brand-50" : "h-main bg-gray-50",
         )}>
         <div

--- a/src/queries/my-notifications.ts
+++ b/src/queries/my-notifications.ts
@@ -1,0 +1,60 @@
+import {
+  deleteMyNotification,
+  listMyNotifications,
+} from "@/src/services/my-notifications";
+import type { GetMyNotificationsProps } from "@/src/types/my-notifications";
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+/**
+ * @description 내 알림 리스트 조회
+ * @param size - 알림 갯수
+ * @param cursorId - 알림 커서 아이디
+ */
+export const useMyNotificationsListQuery = ({
+  size,
+  cursorId,
+}: GetMyNotificationsProps) => {
+  return useQuery({
+    queryKey: ["my-notifications"],
+    queryFn: () => listMyNotifications({ size, cursorId }),
+    refetchInterval: 1000 * 10, // 10초마다 API 호출
+    refetchOnWindowFocus: false, // 탭이 비활성화일 때 API 호출 비활성화
+  });
+};
+
+/**
+ * @description 내 알림 삭제
+ * @param notificationId - 알람 id
+ */
+export const useDeleteMyNotification = () => {
+  // const response = await api.delete(`/my-notifications/${notificationId}`);
+
+  return useMutation({
+    mutationKey: ["my-notifications"],
+    mutationFn: deleteMyNotification,
+    onSuccess(data, variables, context) {
+      console.log(
+        "🚀 ~ onSuccess ~ data, variables, context:",
+        data,
+        variables,
+        context,
+      );
+      /**
+       * @todo
+       * 알림 삭제 성공 토스트 출력
+       */
+    },
+    onError(error, variables, context) {
+      console.log(
+        "🚀 ~ onError ~ error, variables, context:",
+        error,
+        variables,
+        context,
+      );
+      /**
+       * @todo
+       * 알림 삭제 실패 토스트 출력
+       */
+    },
+  });
+};

--- a/src/services/my-notifications.ts
+++ b/src/services/my-notifications.ts
@@ -12,7 +12,7 @@ import {
  * @param size - 알림 갯수
  * @param cursorId - 알림 커서 아이디
  */
-export const getActivity = async ({
+export const listMyNotifications = async ({
   size,
   cursorId,
 }: GetMyNotificationsProps) => {
@@ -31,7 +31,7 @@ export const getActivity = async ({
  * @description 내 알림 삭제
  * @param notificationId - 알람 id
  */
-export const getActivityAvailableSchedule = async ({
+export const deleteMyNotification = async ({
   notificationId,
 }: DeleteMyNotificationProps) => {
   const response = await api.delete(`/my-notifications/${notificationId}`);

--- a/src/types/my-notifications.ts
+++ b/src/types/my-notifications.ts
@@ -11,7 +11,27 @@ export type NotificationId = number;
  */
 export interface GetMyNotificationsProps {
   size?: number;
-  cursorId?: number;
+  cursorId?: number | null;
+}
+
+/**
+ * @description 내 알림 데이터
+ * @param id - 알림 ID;
+ * @param teamId - 팀 ID;
+ * @param userId - 유저 ID;
+ * @param content - 콘텐츠;
+ * @param createdAt - 알림 생성일;
+ * @param updatedAt - 알림 수정일;
+ * @param deletedAt - 알림 삭제알;
+ */
+export interface MyNotificationsProps {
+  id: number;
+  teamId: string;
+  userId: number;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string;
 }
 
 /**

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,7 +5,7 @@ const pxToRem = require("tailwindcss-preset-px-to-rem");
 
 const config: Config = {
   presets: [pxToRem],
-  content: ["./src/**/*.{ts,tsx,js,jsx,mdx}"],
+  content: ["./src/**/*.{ts,tsx,js,jsx,mdx}", "./src/styles/global.css"],
   theme: {
     extend: {
       height: {
@@ -85,6 +85,14 @@ const config: Config = {
     },
   },
   plugins: [],
+  safelist: [
+    {
+      pattern: /bg-*/,
+    },
+    {
+      pattern: /text-*/,
+    },
+  ],
 };
 
 export default config;


### PR DESCRIPTION
# Resolved: #122 

## 🔨 작업내역

- 새로고침 아이콘 추가
- Dropdown 컴포넌트 닫기 버튼 크기 조정
- 테일윈드 설정파일 수정: global.css 인식 & bg-*, text-* 클래스들 safelist 생성
- 알림 객체 타입 추가
- 알림 API 요청 쿼리 생성: interval 로 10초마다 재요청, 해당 탭이 비활성화 중일 때 요청 X
- 알림 내용 중 특정 단어 색상 강조용 컴포넌트 생성: HighlightText (범용으로 사용 가능)
- 알림 있을 시 빨간 점 인디케이터 표출
- 새로고침 버튼으로 재요청 실행
- 각 알림 클릭 시 예약 내역(예약 상태 변경) 또는 예약 현황(신규 예약) 페이지로 이동 (페이지 생성 시 수정 예정)
- 페이지 이동 시 알림창 닫힘 처리
- 알림 UI 퍼블리싱
- 반응형 UI 구현

## 🔊 전달사항

- HighlightText 컴포넌트 사용법은 팀미팅 때 알려드리겠습니다.
- `npm run build` 시 schedule 쪽에서 에러가 발생하고 있습니다. PR 올리기 전에 꼭! 빌드 실행하시고 오류 수정해주세요!
![스크린샷 2025-01-15 18 07 39](https://github.com/user-attachments/assets/baa29e66-8fb0-408b-8578-c56e7675023e)


## 📌 이슈사항

- 아직 실데이터가 없어서 목데이터로 구현되어 있습니다.

## 🎨 예시이미지

> 알림 인디케이터

![스크린샷 2025-01-15 18 18 05](https://github.com/user-attachments/assets/16e55b37-2ac9-4418-87b7-ae9355fcef72)

> 알림 UI

![스크린샷 2025-01-15 18 18 16](https://github.com/user-attachments/assets/cfd1cc16-5b91-4bdf-9387-32bb612488f2)

> 알림 없음 UI

![스크린샷 2025-01-15 18 18 27](https://github.com/user-attachments/assets/7d4127d8-93c1-4b2f-bd96-5224282b08b3)

> 알림 모바일 UI 예시1

![스크린샷 2025-01-16 15 21 46](https://github.com/user-attachments/assets/0540e7c0-7408-4681-81b0-dcd0e3a4ca22)

> 알림 모바일 UI 예시2

![스크린샷 2025-01-16 15 22 07](https://github.com/user-attachments/assets/88256984-2045-4ce8-8888-e3a7fce07131)