### PR TITLE
[feat/#133] 로딩 스피너 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@svgr/webpack": "^8.1.0",
         "@tanstack/react-query": "^5.59.14",
+        "@uiball/loaders": "^1.3.1",
         "axios": "^1.7.7",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -3025,6 +3026,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@uiball/loaders": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@uiball/loaders/-/loaders-1.3.1.tgz",
+      "integrity": "sha512-1vLUoW1aux5CDJedCkW+TYxsnX0WKmmUJMi+wRR4DPEKdTZ2/KP8gQSv/LJu6oc2I0sJceKHFWLeAWO3/og98A==",
+      "deprecated": "This package has been superceded by https://www.npmjs.com/package/ldrs",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@ungap/structured-clone": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@svgr/webpack": "^8.1.0",
     "@tanstack/react-query": "^5.59.14",
+    "@uiball/loaders": "^1.3.1",
     "axios": "^1.7.7",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/src/components/Activity/PopularActivitiesList.tsx
+++ b/src/components/Activity/PopularActivitiesList.tsx
@@ -26,7 +26,6 @@ const PopularActivitiesList = ({
   };
 
   return (
-    // <SectionLayout className="flex flex-col">
     <>
       <div className="flex items-center justify-between">
         <h2 className="font-18px-bold md:font-36px-bold lg:font-36px-bold">

--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -12,9 +12,9 @@ import clsx from "clsx";
 import React from "react";
 
 const Loading = ({
-  isOverlay = "false",
+  isOverlay = "node",
   overlayColor = "translate",
-  isAbsolute = "false",
+  isAbsolute = "static",
   loadingBoxColor = "translate",
   size = 60,
   speed = 0.9,
@@ -29,14 +29,14 @@ const Loading = ({
   return (
     <div
       className={clsx(
-        isOverlay && LOADING_IS_OVERLAY_PRESET[isOverlay],
-        overlayColor && LOADING_OVERLAY_COLOR_PRESET[overlayColor],
-        isAbsolute && LOADING_IS_ABSOLUTE_PRESET[isAbsolute],
+        LOADING_IS_OVERLAY_PRESET[isOverlay],
+        LOADING_OVERLAY_COLOR_PRESET[overlayColor],
+        LOADING_IS_ABSOLUTE_PRESET[isAbsolute],
       )}>
       <div
         className={clsx(
           loadingBoxColor && LOADING_BOX_COLOR_PRESET[loadingBoxColor],
-          isOverlay === "false" && "size-full",
+          isOverlay === "node" && "size-full",
           "flex flex-col items-center justify-center gap-25 rounded-15 text-center",
           className,
         )}>

--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -11,19 +11,6 @@ import { DotSpinner } from "@uiball/loaders";
 import clsx from "clsx";
 import React from "react";
 
-/**
- * @description 로딩 스피너
- * @param isOverlay - 오버레이 여부
- * @param overlayColor - 오버레이 색상
- * @param loadingBoxColor - div 배경 색상
- * @param size - 스피너 크기
- * @param color - 스피너 색상
- * @param loadingText - 스피너와 함께 표시될 메시지
- * @param textStyle - 메시지 텍스트 스타일
- * @param textColor - 메시지 텍스트 색상
- * @param className - 기타 스타일 적용
- */
-
 const Loading = ({
   isOverlay = "false",
   overlayColor = "translate",

--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -1,0 +1,67 @@
+import {
+  LOADING_BOX_COLOR_PRESET,
+  LOADING_IS_ABSOLUTE_PRESET,
+  LOADING_IS_OVERLAY_PRESET,
+  LOADING_OVERLAY_COLOR_PRESET,
+} from "@/src/constants/loading";
+import useResponsiveSpinnerSize from "@/src/hooks/useResponsiveSpinnerSize";
+import { LoadingProps } from "@/src/types/loading";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { DotSpinner } from "@uiball/loaders";
+import clsx from "clsx";
+import React from "react";
+
+/**
+ * @description 로딩 스피너
+ * @param isOverlay - 오버레이 여부
+ * @param overlayColor - 오버레이 색상
+ * @param loadingBoxColor - div 배경 색상
+ * @param size - 스피너 크기
+ * @param color - 스피너 색상
+ * @param loadingText - 스피너와 함께 표시될 메시지
+ * @param textStyle - 메시지 텍스트 스타일
+ * @param textColor - 메시지 텍스트 색상
+ * @param className - 기타 스타일 적용
+ */
+
+const Loading = ({
+  isOverlay = "false",
+  overlayColor = "translate",
+  isAbsolute = "false",
+  loadingBoxColor = "translate",
+  size = 60,
+  speed = 0.9,
+  color = "#8fb2cb",
+  loadingText,
+  textStyle,
+  textColor,
+  className,
+}: LoadingProps) => {
+  const responsiveSize = useResponsiveSpinnerSize(size);
+
+  return (
+    <div
+      className={clsx(
+        isOverlay && LOADING_IS_OVERLAY_PRESET[isOverlay],
+        overlayColor && LOADING_OVERLAY_COLOR_PRESET[overlayColor],
+        isAbsolute && LOADING_IS_ABSOLUTE_PRESET[isAbsolute],
+      )}>
+      <div
+        className={clsx(
+          loadingBoxColor && LOADING_BOX_COLOR_PRESET[loadingBoxColor],
+          isOverlay === "false" && "size-full",
+          "flex flex-col items-center justify-center gap-25 rounded-15 text-center",
+          className,
+        )}>
+        <DotSpinner size={responsiveSize} speed={speed} color={color} />
+        {loadingText ? (
+          <p className={clsx(textStyle, textColor, "!leading-none")}>
+            {loadingText}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default Loading;

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -57,7 +57,7 @@ const Pagination = ({
   return (
     <div>
       <ul className="flex gap-10">
-        <li className={`${noPrev}`}>
+        <li className={clsx(noPrev)}>
           <Button
             type="button"
             radius="15"

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -1,14 +1,24 @@
 import AltArrowLeft from "@/assets/svgs/AltArrowLeft.svg";
 import AltArrowRight from "@/assets/svgs/AltArrowRight.svg";
 import Button from "@/src/components/Button/Button";
+import Loading from "@/src/components/Loading";
 import usePagination from "@/src/hooks/usePagination";
+import useLoadingStore from "@/src/stores/loadingStore";
 import { PaginationProps } from "@/src/types/pagination";
 
+/**
+ * @description
+ * @param totalItems - 데이터 총 개수
+ * @param pageCount -  한 번에 보여줄 페이지 개수
+ * @param currentPage -  현재 페이지
+ * @param itemCountPerPage -  페이지 당 데이터 개수
+ */
+
 const Pagination = ({
-  totalItems, // 데이터 총 개수
-  pageCount, // 한 번에 보여줄 페이지 개수
-  currentPage, // 현재 페이지
-  itemCountPerPage, // 페이지 당 데이터 개수
+  totalItems,
+  pageCount,
+  currentPage,
+  itemCountPerPage,
 }: PaginationProps) => {
   const { start, noPrev, noNext, navigateToPage, totalPages } = usePagination({
     totalItems,
@@ -18,6 +28,30 @@ const Pagination = ({
   });
   const buttonSize = "w-40 h-40 sm:w-55 sm:h-55";
   const iconSize = "w-21 h-21";
+
+  // loading spinner
+  const { loadingButtons, showLoadingButtons, hideLoadingButtons } =
+    useLoadingStore();
+
+  const handlePageClick = async (pageNumber: number) => {
+    showLoadingButtons(pageNumber);
+    try {
+      await navigateToPage(pageNumber);
+    } finally {
+      hideLoadingButtons(pageNumber);
+    }
+  };
+
+  const loadingSpinner = (
+    <Loading
+      isOverlay="false"
+      overlayColor="translate"
+      isAbsolute="false"
+      loadingBoxColor="translate"
+      color="#ffffff"
+      size={35}
+    />
+  );
 
   return (
     <div>
@@ -29,12 +63,16 @@ const Pagination = ({
             gap="10"
             backgroundColor={noPrev ? "white_gray" : "white_green"}
             disabled={noPrev}
-            className={`${buttonSize}`}
-            onClick={() => navigateToPage(start - 1)}>
-            <AltArrowLeft
-              className={`${iconSize} ${noPrev ? "text-gray-600" : "text-brand-400"}`}
-              aria-label="이전 페이지로 이동 버튼"
-            />
+            className={`${buttonSize} relative`}
+            onClick={() => handlePageClick(start - 1)}>
+            {loadingButtons?.[start - 1] ? (
+              loadingSpinner
+            ) : (
+              <AltArrowLeft
+                className={`${iconSize} ${noPrev ? "text-gray-600" : "text-brand-400"}`}
+                aria-label="이전 페이지로 이동 버튼"
+              />
+            )}
           </Button>
         </li>
         {Array.from({ length: pageCount }).map((_, i) => {
@@ -52,8 +90,8 @@ const Pagination = ({
                   fontStyle={isActivePage ? "xxxl" : "xxl"}
                   disabled={isActivePage}
                   className={`${buttonSize}`}
-                  onClick={() => navigateToPage(pageNumber)}>
-                  {pageNumber}
+                  onClick={() => handlePageClick(pageNumber)}>
+                  {loadingButtons?.[pageNumber] ? loadingSpinner : pageNumber}
                 </Button>
               </li>
             )
@@ -67,11 +105,15 @@ const Pagination = ({
             backgroundColor={noNext ? "white_gray" : "white_green"}
             className={`${buttonSize}`}
             disabled={noNext}
-            onClick={() => navigateToPage(start + pageCount)}>
-            <AltArrowRight
-              className={`${iconSize} ${noNext ? "text-gray-600" : "text-brand-400"}`}
-              aria-label="다음 페이지로 이동 버튼"
-            />
+            onClick={() => handlePageClick(start + pageCount)}>
+            {loadingButtons?.[start + pageCount] ? (
+              loadingSpinner
+            ) : (
+              <AltArrowRight
+                className={`${iconSize} ${noNext ? "text-gray-600" : "text-brand-400"}`}
+                aria-label="다음 페이지로 이동 버튼"
+              />
+            )}
           </Button>
         </li>
       </ul>

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -44,9 +44,9 @@ const Pagination = ({
 
   const loadingSpinner = (
     <Loading
-      isOverlay="false"
+      isOverlay="node"
       overlayColor="translate"
-      isAbsolute="false"
+      isAbsolute="static"
       loadingBoxColor="translate"
       color="#ffffff"
       size={35}

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -5,6 +5,7 @@ import Loading from "@/src/components/Loading";
 import usePagination from "@/src/hooks/usePagination";
 import useLoadingStore from "@/src/stores/loadingStore";
 import { PaginationProps } from "@/src/types/pagination";
+import clsx from "clsx";
 
 /**
  * @description
@@ -63,13 +64,16 @@ const Pagination = ({
             gap="10"
             backgroundColor={noPrev ? "white_gray" : "white_green"}
             disabled={noPrev}
-            className={`${buttonSize} relative`}
+            className={clsx(buttonSize, "relative")}
             onClick={() => handlePageClick(start - 1)}>
             {loadingButtons?.[start - 1] ? (
               loadingSpinner
             ) : (
               <AltArrowLeft
-                className={`${iconSize} ${noPrev ? "text-gray-600" : "text-brand-400"}`}
+                className={clsx(
+                  iconSize,
+                  noPrev ? "text-gray-600" : "text-brand-400",
+                )}
                 aria-label="이전 페이지로 이동 버튼"
               />
             )}
@@ -89,7 +93,7 @@ const Pagination = ({
                   backgroundColor={isActivePage ? "green" : "white_green"}
                   fontStyle={isActivePage ? "xxxl" : "xxl"}
                   disabled={isActivePage}
-                  className={`${buttonSize}`}
+                  className={buttonSize}
                   onClick={() => handlePageClick(pageNumber)}>
                   {loadingButtons?.[pageNumber] ? loadingSpinner : pageNumber}
                 </Button>
@@ -103,7 +107,7 @@ const Pagination = ({
             radius="15"
             gap="10"
             backgroundColor={noNext ? "white_gray" : "white_green"}
-            className={`${buttonSize}`}
+            className={buttonSize}
             disabled={noNext}
             onClick={() => handlePageClick(start + pageCount)}>
             {loadingButtons?.[start + pageCount] ? (

--- a/src/constants/loading.ts
+++ b/src/constants/loading.ts
@@ -6,8 +6,8 @@ import {
 } from "@/src/types/loading";
 
 export const LOADING_IS_OVERLAY_PRESET: Record<LoadingIsOverlayType, string> = {
-  true: "fixed inset-0 z-50 flex flex-col items-center justify-center",
-  false: "size-full z-50 flex flex-col items-center justify-center",
+  window: "fixed inset-0 z-50 flex flex-col items-center justify-center",
+  node: "size-full z-50 flex flex-col items-center justify-center",
 };
 
 export const LOADING_OVERLAY_COLOR_PRESET: Record<
@@ -21,8 +21,8 @@ export const LOADING_OVERLAY_COLOR_PRESET: Record<
 
 export const LOADING_IS_ABSOLUTE_PRESET: Record<LoadingIsAbsoluteType, string> =
   {
-    true: "absolute",
-    false: "static",
+    absolute: "absolute",
+    static: "static",
   };
 
 export const LOADING_BOX_COLOR_PRESET: Record<LoadingBoxColorType, string> = {

--- a/src/constants/loading.ts
+++ b/src/constants/loading.ts
@@ -1,0 +1,31 @@
+import {
+  LoadingBoxColorType,
+  LoadingIsAbsoluteType,
+  LoadingIsOverlayType,
+  LoadingOverlayColorType,
+} from "@/src/types/loading";
+
+export const LOADING_IS_OVERLAY_PRESET: Record<LoadingIsOverlayType, string> = {
+  true: "fixed inset-0 z-50 flex flex-col items-center justify-center",
+  false: "size-full z-50 flex flex-col items-center justify-center",
+};
+
+export const LOADING_OVERLAY_COLOR_PRESET: Record<
+  LoadingOverlayColorType,
+  string
+> = {
+  translate: "bg-translate",
+  white: "bg-neutral-100/80",
+  blue: "bg-slate-400/80",
+};
+
+export const LOADING_IS_ABSOLUTE_PRESET: Record<LoadingIsAbsoluteType, string> =
+  {
+    true: "absolute",
+    false: "static",
+  };
+
+export const LOADING_BOX_COLOR_PRESET: Record<LoadingBoxColorType, string> = {
+  translate: "bg-translate",
+  black: "bg-black/70",
+};

--- a/src/hooks/useResponsiveSpinnerSize.tsx
+++ b/src/hooks/useResponsiveSpinnerSize.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+
+const useResponsiveSpinnerSize = (
+  size: number | { sm?: number; md?: number; lg?: number },
+  defaultSize = 60,
+) => {
+  const [spinnerSize, setSpinnerSize] = useState<number>(defaultSize);
+
+  // loading spinner 크기 계산
+  useEffect(() => {
+    const getResponsiveSize = () => {
+      if (typeof size === "number") {
+        setSpinnerSize(size);
+        return;
+      }
+
+      if (typeof size === "object") {
+        const width = window.innerWidth;
+        if (width >= 1024 && size.lg) {
+          setSpinnerSize(size.lg);
+        } else if (width >= 768 && size.md) {
+          setSpinnerSize(size.md);
+        } else if (size.sm) {
+          setSpinnerSize(size.sm);
+        }
+      }
+    };
+
+    getResponsiveSize();
+    window.addEventListener("resize", getResponsiveSize);
+    return () => window.removeEventListener("resize", getResponsiveSize);
+  }, [size]);
+
+  return spinnerSize;
+};
+
+export default useResponsiveSpinnerSize;

--- a/src/pages/pagination/index.tsx
+++ b/src/pages/pagination/index.tsx
@@ -87,9 +87,9 @@ const PaginationPage = () => {
       {/* loading spinner */}
       {isLoading && (
         <Loading
-          isOverlay="true"
+          isOverlay="window"
           overlayColor="blue"
-          isAbsolute="false"
+          isAbsolute="static"
           loadingBoxColor="black"
           size={{ sm: 50, md: 60, lg: 70 }}
           loadingText="잠시만 기다려주세요."
@@ -123,9 +123,9 @@ const PaginationPage = () => {
                   />
                   {loadingButtons?.[activity.id] ? (
                     <Loading
-                      isOverlay="false"
+                      isOverlay="node"
                       overlayColor="translate"
-                      isAbsolute="true"
+                      isAbsolute="absolute"
                       loadingBoxColor="black"
                       color="gray"
                       size={70}

--- a/src/pages/pagination/index.tsx
+++ b/src/pages/pagination/index.tsx
@@ -56,7 +56,6 @@ const PaginationPage = () => {
     showLoading,
     hideLoading,
     showLoadingButtons,
-    hideLoadingButtons,
   } = useLoadingStore();
 
   useEffect(() => {

--- a/src/pages/pagination/index.tsx
+++ b/src/pages/pagination/index.tsx
@@ -1,14 +1,16 @@
 import Star from "@/assets/svgs/star.svg";
+import Loading from "@/src/components/Loading";
 import Pagination from "@/src/components/Pagination/index";
+import useLoadingStore from "@/src/stores/loadingStore";
 import { Activity } from "@/src/types/activities";
 import Image from "next/image";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
 const PaginationPage = () => {
   const router = useRouter();
 
-  const [loading, setLoading] = useState(true);
   const [page, setPage] = useState<number | null>(null);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [sort, setSort] = useState("latest");
@@ -47,9 +49,19 @@ const PaginationPage = () => {
     }
   }, [router.isReady, router.query.page, page, router]);
 
+  // loading spinner
+  const {
+    isLoading,
+    loadingButtons,
+    showLoading,
+    hideLoading,
+    showLoadingButtons,
+    hideLoadingButtons,
+  } = useLoadingStore();
+
   useEffect(() => {
     const fetchData = async () => {
-      setLoading(true);
+      showLoading();
       try {
         if (page !== null) {
           const response = await fetch(
@@ -58,59 +70,87 @@ const PaginationPage = () => {
           const data = await response.json();
           setActivities(data.activities);
           setTotalCount(data.totalCount);
-          setLoading(false);
+          hideLoading();
         }
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error("데이터 페칭 오류", error);
-        setLoading(false);
+        hideLoading();
         throw error;
       }
     };
     fetchData();
-  }, [page, sort, size]);
+  }, [page, sort, size, showLoading, hideLoading]);
 
   return (
     <>
+      {/* loading spinner */}
+      {isLoading && (
+        <Loading
+          isOverlay="true"
+          overlayColor="blue"
+          isAbsolute="false"
+          loadingBoxColor="black"
+          size={{ sm: 50, md: 60, lg: 70 }}
+          loadingText="잠시만 기다려주세요."
+          textStyle="font-18px-medium md:font-20px-regular lg:font-24px-regular"
+          textColor="text-brand-50"
+          className="p-30"
+        />
+      )}
+
       {/* 메인 화면 */}
       <div className="my-20">
         <header className="font-36px-bold mb-8">🛼 모든 체험</header>
-        {loading ? (
-          <div>Loading...</div>
-        ) : (
-          <div className="grid grid-cols-2 grid-rows-2 gap-x-8 gap-y-5 md:grid-cols-3 md:grid-rows-3 md:gap-x-16 md:gap-y-32 lg:grid-cols-4 lg:grid-rows-2 lg:gap-x-24 lg:gap-y-48">
-            {Array.isArray(activities) && activities.length > 0 ? (
-              activities.map((activity) => (
-                <div key={activity.id}>
-                  <div className="relative aspect-[1/1] w-full">
-                    <Image
-                      src={activity.bannerImageUrl}
-                      alt="activity.title"
-                      className="rounded-2xl object-cover"
-                      fill
-                      sizes="(max-width: 640px) 168px, (max-width: 768px) 221px, 283px"
-                      priority
+
+        <div className="grid grid-cols-2 grid-rows-2 gap-x-8 gap-y-5 md:grid-cols-3 md:grid-rows-3 md:gap-x-16 md:gap-y-32 lg:grid-cols-4 lg:grid-rows-2 lg:gap-x-24 lg:gap-y-48">
+          {Array.isArray(activities) && activities.length > 0 ? (
+            activities.map((activity) => (
+              <Link
+                href={`https://sp-globalnomad-api.vercel.app/6-1/activities/${activity.id}`}
+                key={activity.id}
+                onClick={() => {
+                  showLoadingButtons(activity.id);
+                }}>
+                <div className="relative aspect-[1/1] w-full">
+                  <Image
+                    src={activity.bannerImageUrl}
+                    alt="activity.title"
+                    className="rounded-2xl object-cover"
+                    fill
+                    sizes="(max-width: 640px) 168px, (max-width: 768px) 221px, 283px"
+                    priority
+                  />
+                  {loadingButtons?.[activity.id] ? (
+                    <Loading
+                      isOverlay="false"
+                      overlayColor="translate"
+                      isAbsolute="true"
+                      loadingBoxColor="black"
+                      color="gray"
+                      size={70}
                     />
-                  </div>
-                  <div className="flex">
-                    <Star alt="별점 아이콘" />
-                    <p>3.9</p>
-                    <p>(108)</p>
-                  </div>
-                  <p className="lg:font-24px-semibold font-18px-semibold overflow-hidden text-ellipsis text-nowrap">
-                    {activity.title}
-                  </p>
-                  <div className="flex">
-                    <p>₩ 42,800</p>
-                    <p>/인</p>
-                  </div>
+                  ) : null}
                 </div>
-              ))
-            ) : (
-              <p>체험이 없습니다.</p>
-            )}
-          </div>
-        )}
+                <div className="flex">
+                  <Star alt="별점 아이콘" />
+                  <p>3.9</p>
+                  <p>(108)</p>
+                </div>
+                <p className="lg:font-24px-semibold font-18px-semibold overflow-hidden text-ellipsis text-nowrap">
+                  {activity.title}
+                </p>
+                <div className="flex">
+                  <p>₩ 42,800</p>
+                  <p>/인</p>
+                </div>
+              </Link>
+            ))
+          ) : (
+            <p>체험이 없습니다.</p>
+          )}
+        </div>
+
         <div className="mt-64 flex w-full justify-center">
           <Pagination
             totalItems={totalCount}

--- a/src/stores/loadingStore.ts
+++ b/src/stores/loadingStore.ts
@@ -1,0 +1,44 @@
+import { create } from "zustand";
+
+/**
+ * @description 로딩 상태 관리
+ * @param isLoading - ID 없을 때 로딩 상태
+ * @param showLoading - 로딩 상태를 활성화하는 함수
+ * @param hideLoading - 로딩 상태를 비활성화하는 함수
+ * @param loadingButtons - 버튼 ID별 로딩 상태
+ * @param showLoadingButtons - 로딩 상태를 활성화하는 함수
+ * @param hideLoadingButtons - 로딩 상태를 비활성화하는 함수
+ */
+
+type LoadingState = {
+  isLoading?: boolean;
+  showLoading: () => void;
+  hideLoading: () => void;
+  loadingButtons?: Record<number, boolean>;
+  showLoadingButtons: (id: number) => void;
+  hideLoadingButtons: (id: number) => void;
+};
+
+const useLoadingStore = create<LoadingState>((set) => ({
+  isLoading: false,
+  loadingButtons: {},
+  showLoading: () =>
+    set(() => ({
+      isLoading: true,
+    })),
+  hideLoading: () =>
+    set(() => ({
+      isLoading: false,
+    })),
+
+  showLoadingButtons: (id) =>
+    set((state) => ({
+      loadingButtons: { ...state.loadingButtons, [id]: true },
+    })),
+  hideLoadingButtons: (id) =>
+    set((state) => ({
+      loadingButtons: { ...state.loadingButtons, [id]: false },
+    })),
+}));
+
+export default useLoadingStore;

--- a/src/types/loading.ts
+++ b/src/types/loading.ts
@@ -1,0 +1,38 @@
+/**
+ * @description 로딩 스피너
+ * @param isOverlay - overlay 여부
+ * @param overlayColor - overlay 색상
+ * @param isAbsolute - 스피너 absolute 사용 여부
+ * @param loadingBoxColor - loadingBox 색상(숫자 또는 객체로 전달)
+ * @param speed - 로딩 스피너 속도
+ * @param color - 로딩 스피너 색상
+ * @param loadingText - 메시지
+ * @param textStyle - 메시지 폰트 스타일
+ * @param textColor - 메시지 폰트 색상
+ * @param className -
+ */
+
+export interface LoadingProps extends React.HTMLAttributes<HTMLDivElement> {
+  isOverlay: LoadingIsOverlayType;
+  overlayColor: LoadingOverlayColorType;
+  isAbsolute: LoadingIsAbsoluteType;
+  loadingBoxColor: LoadingBoxColorType;
+  size?:
+    | number
+    | {
+        sm?: number;
+        md?: number;
+        lg?: number;
+      };
+  speed?: number;
+  color?: string;
+  loadingText?: string;
+  textStyle?: string;
+  textColor?: string;
+  className?: string;
+}
+
+export type LoadingIsOverlayType = "true" | "false";
+export type LoadingOverlayColorType = "translate" | "white" | "blue";
+export type LoadingIsAbsoluteType = "true" | "false";
+export type LoadingBoxColorType = "translate" | "black";

--- a/src/types/loading.ts
+++ b/src/types/loading.ts
@@ -1,3 +1,8 @@
+export type LoadingIsOverlayType = "window" | "node";
+export type LoadingOverlayColorType = "translate" | "white" | "blue";
+export type LoadingIsAbsoluteType = "absolute" | "static";
+export type LoadingBoxColorType = "translate" | "black";
+
 /**
  * @description 로딩 스피너
  * @param isOverlay - overlay 여부
@@ -31,8 +36,3 @@ export interface LoadingProps extends React.HTMLAttributes<HTMLDivElement> {
   textColor?: string;
   className?: string;
 }
-
-export type LoadingIsOverlayType = "window" | "node";
-export type LoadingOverlayColorType = "translate" | "white" | "blue";
-export type LoadingIsAbsoluteType = "absolute" | "static";
-export type LoadingBoxColorType = "translate" | "black";

--- a/src/types/loading.ts
+++ b/src/types/loading.ts
@@ -32,7 +32,7 @@ export interface LoadingProps extends React.HTMLAttributes<HTMLDivElement> {
   className?: string;
 }
 
-export type LoadingIsOverlayType = "true" | "false";
+export type LoadingIsOverlayType = "window" | "node";
 export type LoadingOverlayColorType = "translate" | "white" | "blue";
-export type LoadingIsAbsoluteType = "true" | "false";
+export type LoadingIsAbsoluteType = "absolute" | "static";
 export type LoadingBoxColorType = "translate" | "black";

--- a/src/types/loading.ts
+++ b/src/types/loading.ts
@@ -9,7 +9,7 @@
  * @param loadingText - 메시지
  * @param textStyle - 메시지 폰트 스타일
  * @param textColor - 메시지 폰트 색상
- * @param className -
+ * @param className - 로딩 박스 기타 스타일 적용
  */
 
 export interface LoadingProps extends React.HTMLAttributes<HTMLDivElement> {


### PR DESCRIPTION
# Resolved: #133 

## 🔨 작업 내역
- 로딩 스피너 구현
  - props로 커스텀 가능(`types/loading.ts` 참고)
- Pagination 버튼에 로딩 스피너 적용

<br/>

## 🔊 전달 사항
- 적용 예시 페이지: `src/pages/pagination`
- 사용 예시 코드:
  `src/pages/pagination/index.tsx`
  `src/components/Pagination/index.tsx`
- 페이지 전체적으로 사용할 때: `isLoading` 사용
  페이지네이션 또는 일부 체험과 같이 일부 요소에 사용 시 `loadingButtons` 사용

<br/>

## 🎨 예시 이미지
- 페이지 이동
  ![image](https://github.com/user-attachments/assets/36afdcc3-cb9f-45ba-a041-20ab7570042d)
- 체험 클릭
  ![image](https://github.com/user-attachments/assets/5eb55e2e-bc65-4ca3-8982-a0e5c8918be3)
- 페이지네이션 버튼 클릭
  ![image](https://github.com/user-attachments/assets/c81e0433-efbd-44c3-9f26-a2f4b9c91904)
- 동작 예시
  ![250124_로딩스피너 (1)](https://github.com/user-attachments/assets/729dce9d-d3dd-4c2d-8e57-118b01fe9851)