### PR TITLE
[fix/#156] 사용자 프로필 위치, 테두리 수정

### DIFF
--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -50,7 +50,7 @@ const Avatar = () => {
               "absolute -inset-4 rounded-full border-2 text-[0]",
               userProvider
                 ? AVATAR_TYPES[userProvider].className
-                : "border-brand-400",
+                : "border-b-brand-300 border-l-brand-200 border-r-brand-400 border-t-brand-500",
             )}>
             {userProvider ? AVATAR_TYPES[userProvider].context : "일반"} 계정
           </div>

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -1,6 +1,7 @@
 import IconUser from "@/assets/svgs/ic_user.svg";
 import useUserStore from "@/src/stores/userStore";
 import { ProfileImageUrl } from "@/src/types/user";
+import clsx from "clsx";
 
 const Avatar = () => {
   const { userData, userProvider } = useUserStore();
@@ -20,6 +21,18 @@ const Avatar = () => {
     }
   })();
 
+  const AVATAR_TYPES = {
+    kakao: {
+      context: "카카오",
+      className: "border-[#fae100]",
+    },
+    google: {
+      context: "구글",
+      className:
+        "border-b-[#34A853] border-l-[#FBBC04] border-r-[#4285F4] border-t-[#EA4335]",
+    },
+  };
+
   if (!userData) return null;
 
   return (
@@ -32,15 +45,15 @@ const Avatar = () => {
             alt={profileImageUrl.name}
             className="relative size-32 rounded-full"
           />
-          {userProvider && userProvider === "kakao" ? (
-            <div className="absolute -inset-4 rounded-full border-2 border-[#fae100] text-[0]">
-              카카오 계정
-            </div>
-          ) : (
-            <div className="absolute -inset-4 rounded-full border-2 border-b-[#34A853] border-l-[#FBBC04] border-r-[#4285F4] border-t-[#EA4335] text-[0]">
-              구글 계정
-            </div>
-          )}
+          <div
+            className={clsx(
+              "absolute -inset-4 rounded-full border-2 text-[0]",
+              userProvider
+                ? AVATAR_TYPES[userProvider].className
+                : "border-brand-400",
+            )}>
+            {userProvider ? AVATAR_TYPES[userProvider].context : "일반"} 계정
+          </div>
         </div>
       ) : (
         <IconUser className="text-brand-600" />

--- a/src/components/UserProfile/index.tsx
+++ b/src/components/UserProfile/index.tsx
@@ -13,7 +13,7 @@ const UserProfile = () => {
       <Dropdown.Trigger>
         <Avatar />
       </Dropdown.Trigger>
-      <Dropdown.Menu>
+      <Dropdown.Menu className="left-auto right-0">
         <Dropdown.Item onClick={() => router.push(PATH_NAMES.MyPage)}>
           마이페이지
         </Dropdown.Item>


### PR DESCRIPTION
# Resolved: #156 

## 🔨 작업내역

- 사용자 드롭다운 메뉴 위치 오른쪽 기준으로 수정
- 사용자 프로필 테두리 `[ 카카오, 구글, 일반 ]` 세가지 색상으로 수정

## 🔊 전달사항

- 구글 로그인은 지원하지 않지만 일반 계정은 브랜드 컬러로 표현될 수 있게 수정했습니다.