### PR TITLE
[fix/#178] Dropdown 이벤트 전파 수정

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -73,6 +73,7 @@ Dropdown.Trigger = ({
       )}
       onClick={(event: MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();
+        event.preventDefault();
         if (typeof onClick === "function") onClick();
         toggle();
       }}
@@ -109,13 +110,18 @@ Dropdown.Item = ({
 
   return (
     <button
+      type="button"
       className={clsx(
         "relative block w-full text-nowrap rounded-none",
         className,
       )}
-      type="button"
+      onClick={(event: MouseEvent<HTMLButtonElement>) => {
+        event.stopPropagation();
+        event.preventDefault();
+      }}
       onMouseDown={(event: MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();
+        event.preventDefault();
         if (typeof onClick === "function") onClick();
         toggle();
       }}


### PR DESCRIPTION
# Resolved: #178

## 🔨 작업내역

- Dropdown.Trigger onClick 이벤트 수정
- Dropdown.Item onClick 이벤트 수정

## 🔊 전달사항

`Link` 컴포넌트의 자손으로 `Dropdown` 컴포넌트 사용시 `Link` 가 작동하는 문제가 있었습니다.
`Dropdown.Trigger` 의 `onClick` 에서 기존 이벤트를 취소하는 코드가 필요하여
`Trigger` 와 `Item` 의 `onClick` 프롭에
```js
event.stopPropagation();
event.preventDefault();
```
를 추가했습니다.
