### PR TITLE
[fix/#186] 컴파일 에러 수정

### DIFF
--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -1,5 +1,5 @@
-import AltArrowLeft from "@/assets/svgs/AltArrowLeft.svg";
-import AltArrowRight from "@/assets/svgs/AltArrowRight.svg";
+import AltArrowLeft from "@/assets/svgs/altArrowLeft.svg";
+import AltArrowRight from "@/assets/svgs/altArrowRight.svg";
 import Button from "@/src/components/Button/Button";
 import Loading from "@/src/components/Loading";
 import usePagination from "@/src/hooks/usePagination";

--- a/src/constants/carousel.ts
+++ b/src/constants/carousel.ts
@@ -1,14 +1,14 @@
-import mainImage1 from "@/assets/mainBanner/mainImage1.avif";
-import mainImage2 from "@/assets/mainBanner/mainImage2.avif";
-import mainImage3 from "@/assets/mainBanner/mainImage3.avif";
-import mainImage4 from "@/assets/mainBanner/mainImage4.avif";
-import mainImage5 from "@/assets/mainBanner/mainImage5.avif";
-import mainImage6 from "@/assets/mainBanner/mainImage6.avif";
-import mainImage7 from "@/assets/mainBanner/mainImage7.avif";
-import mainImage8 from "@/assets/mainBanner/mainImage8.avif";
-import mainImage9 from "@/assets/mainBanner/mainImage9.avif";
-import mainImage10 from "@/assets/mainBanner/mainImage10.avif";
-import mainImage11 from "@/assets/mainBanner/mainImage11.avif";
+import mainImage1 from "@/assets/mainBanner/mainimage1.avif";
+import mainImage2 from "@/assets/mainBanner/mainimage2.avif";
+import mainImage3 from "@/assets/mainBanner/mainimage3.avif";
+import mainImage4 from "@/assets/mainBanner/mainimage4.avif";
+import mainImage5 from "@/assets/mainBanner/mainimage5.avif";
+import mainImage6 from "@/assets/mainBanner/mainimage6.avif";
+import mainImage7 from "@/assets/mainBanner/mainimage7.avif";
+import mainImage8 from "@/assets/mainBanner/mainimage8.avif";
+import mainImage9 from "@/assets/mainBanner/mainimage9.avif";
+import mainImage10 from "@/assets/mainBanner/mainimage10.avif";
+import mainImage11 from "@/assets/mainBanner/mainimage11.avif";
 import { CarouselItem } from "@/src/types/carousel";
 
 const CAROUSEL_ITEM: CarouselItem[] = [

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,7 +1,7 @@
 import ButtonProps from "../types/button";
 import lottieJson from "@/assets/json/404.json";
-import AltArrowLeft from "@/assets/svgs/AltArrowLeft.svg";
-import AltArrowRight from "@/assets/svgs/AltArrowRight.svg";
+import AltArrowLeft from "@/assets/svgs/altArrowLeft.svg";
+import AltArrowRight from "@/assets/svgs/altArrowRight.svg";
 import Button from "@/src/components/Button/Button";
 import { NextPage } from "next";
 import { useRouter } from "next/router";

--- a/src/pages/button/index.tsx
+++ b/src/pages/button/index.tsx
@@ -1,4 +1,4 @@
-import AltArrowLeft from "@/assets/svgs/AltArrowLeft.svg";
+import AltArrowLeft from "@/assets/svgs/altArrowLeft.svg";
 import BtnArrow48pxDefault from "@/assets/svgs/btnArrow48pxDefault.svg";
 import BtnArrow48pxVariant4 from "@/assets/svgs/btnArrow48pxVariant4.svg";
 import Close from "@/assets/svgs/close.svg";


### PR DESCRIPTION
# Resolved: #186 

## 🔨 작업내역

- import 의 `AltArrowLeft.svg`, `AltArrowRight.svg` 대문자를 파일에 맞게 소문자로 수정
- import 의 `/assets/mainBanner/` 의 mainimage 들 파일에 맞게 카멜케이스를 소문자로 수정

## 📌 이슈사항

- 배포 중 컴파일 에러가 발생했습니다!

## 👩‍🔧 오류내역

```
[21:27:41.401] Running build in Washington, D.C., USA (East) – iad1
[21:27:41.512] Cloning github.com/vivi-trip/vivitrip (Branch: dev, Commit: 494cf20)
[21:27:41.611] Previous build caches not available
[21:27:42.070] Cloning completed: 558.000ms
[21:27:42.401] Running "vercel build"
[21:27:42.783] Vercel CLI 41.2.2
[21:27:43.087] Installing dependencies...
[21:27:45.864] npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
[21:27:46.802] npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
[21:27:46.972] npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
[21:27:48.332] npm warn deprecated @humanwhocodes/config-array@0.13.0: Use @eslint/config-array instead
[21:27:48.333] npm warn deprecated @humanwhocodes/object-schema@2.0.3: Use @eslint/object-schema instead
[21:27:49.804] npm warn deprecated @uiball/loaders@1.3.1: This package has been superceded by https://www.npmjs.com/package/ldrs
[21:27:52.349] npm warn deprecated eslint@8.57.1: This version is no longer supported. Please see https://eslint.org/version-support for other options.
[21:28:03.083] 
[21:28:03.083] added 788 packages in 20s
[21:28:03.083] 
[21:28:03.083] 217 packages are looking for funding
[21:28:03.083]   run `npm fund` for details
[21:28:03.163] Detected Next.js version: 15.2.1
[21:28:03.171] Running "npm run build"
[21:28:03.287] 
[21:28:03.287] > vivitrip@0.1.0 build
[21:28:03.288] > next build
[21:28:03.288] 
[21:28:03.891] Attention: Next.js now collects completely anonymous telemetry regarding usage.
[21:28:03.891] This information is used to shape Next.js' roadmap and prioritize features.
[21:28:03.892] You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
[21:28:03.892] https://nextjs.org/telemetry
[21:28:03.892] 
[21:28:03.951]    ▲ Next.js 15.2.1
[21:28:03.951] 
[21:28:04.000]    Linting and checking validity of types ...
[21:28:27.973] 
[21:28:27.973] ./src/components/MyReservations/ReservationCard.tsx
[21:28:27.973] 7:10  Warning: 'ReservationStatus' is defined but never used.  @typescript-eslint/no-unused-vars
[21:28:27.973] 71:11  Warning: Unexpected console statement.  no-console
[21:28:27.973] 
[21:28:27.973] ./src/components/MyReservations/ReservationList.tsx
[21:28:27.973] 8:11  Warning: 'data' is assigned a value but never used.  @typescript-eslint/no-unused-vars
[21:28:27.973] 
[21:28:27.973] ./src/components/ReservationHistory/ReservationHistoryCalendar.tsx
[21:28:27.973] 5:10  Warning: 'useGetMyReservationDashboard' is defined but never used.  @typescript-eslint/no-unused-vars
[21:28:27.973] 147:10  Warning: 'currentMonth' is assigned a value but never used.  @typescript-eslint/no-unused-vars
[21:28:27.974] 148:10  Warning: 'currentYear' is assigned a value but never used.  @typescript-eslint/no-unused-vars
[21:28:27.974] 223:7  Warning: Unexpected console statement.  no-console
[21:28:27.974] 
[21:28:27.974] ./src/components/SideNavigationMenu/SideNavigationMenu.tsx
[21:28:27.974] 19:11  Warning: 'setModalOpen' is assigned a value but never used.  @typescript-eslint/no-unused-vars
[21:28:27.974] 
[21:28:27.974] ./src/components/SideNavigationMenu/common/ProfileUpload.tsx
[21:28:27.974] 38:9  Warning: Unexpected console statement.  no-console
[21:28:27.974] 
[21:28:27.974] ./src/components/calendar/Calendar.tsx
[21:28:27.974] 2:23  Warning: 'useCalendarStore' is defined but never used.  @typescript-eslint/no-unused-vars
[21:28:27.974] 
[21:28:27.974] ./src/components/modal/ReservationInfoModal/ReservationInfoModal.tsx
[21:28:27.974] 10:3  Warning: 'ReservationInfosType' is defined but never used.  @typescript-eslint/no-unused-vars
[21:28:27.974] 62:9  Warning: 'mockReservationSchedules' is assigned a value but never used.  @typescript-eslint/no-unused-vars
[21:28:27.975] 73:17  Warning: 'reservedTimeData' is assigned a value but never used.  @typescript-eslint/no-unused-vars
[21:28:27.975] 
[21:28:27.975] ./src/components/shortDropdown/shortDropdownMenu.tsx
[21:28:27.975] 19:18  Warning: Classname 'border-opacity-10' should be replaced by an opacity suffix (eg. '/10')  tailwindcss/migration-from-tailwind-2
[21:28:27.975] 19:18  Warning: Classname 'z-dropdown' is not a Tailwind CSS class!  tailwindcss/no-custom-classname
[21:28:27.975] 19:18  Warning: Classname 'bg-background-secondary' is not a Tailwind CSS class!  tailwindcss/no-custom-classname
[21:28:27.975] 19:18  Warning: Classname 'dark:bg-background-secondary-dark' is not a Tailwind CSS class!  tailwindcss/no-custom-classname
[21:28:27.975] 19:18  Warning: Classname 'border-background-tertiary' is not a Tailwind CSS class!  tailwindcss/no-custom-classname
[21:28:27.975] 19:18  Warning: Classname 'dark:border-background-tertiary-dark' is not a Tailwind CSS class!  tailwindcss/no-custom-classname
[21:28:27.975] 
[21:28:27.975] ./src/pages/modal/index.tsx
[21:28:27.976] 6:8  Warning: 'ReviewModal' is defined but never used.  @typescript-eslint/no-unused-vars
[21:28:27.976] 
[21:28:27.976] ./src/pages/short-dropdown/index.tsx
[21:28:27.976] 24:16  Warning: Classname 'text-18px-semibold' is not a Tailwind CSS class!  tailwindcss/no-custom-classname
[21:28:27.976] 
[21:28:27.976] ./src/services/activities.ts
[21:28:27.976] 9:3  Warning: 'CreateActivityImageUrlProps' is defined but never used.  @typescript-eslint/no-unused-vars
[21:28:27.976] 
[21:28:27.976] info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
[21:28:28.007]    Creating an optimized production build ...
[21:28:38.290] Failed to compile.
[21:28:38.290] 
[21:28:38.290] ./src/components/Pagination/index.tsx
[21:28:38.290] Module not found: Can't resolve '@/assets/svgs/AltArrowLeft.svg'
[21:28:38.290] 
[21:28:38.290] https://nextjs.org/docs/messages/module-not-found
[21:28:38.291] 
[21:28:38.291] Import trace for requested module:
[21:28:38.291] ./src/pages/pagination/index.tsx
[21:28:38.291] 
[21:28:38.291] ./src/components/Pagination/index.tsx
[21:28:38.291] Module not found: Can't resolve '@/assets/svgs/AltArrowRight.svg'
[21:28:38.291] 
[21:28:38.291] https://nextjs.org/docs/messages/module-not-found
[21:28:38.291] 
[21:28:38.291] Import trace for requested module:
[21:28:38.291] ./src/pages/pagination/index.tsx
[21:28:38.291] 
[21:28:38.291] ./src/constants/carousel.ts
[21:28:38.291] Module not found: Can't resolve '@/assets/mainBanner/mainImage1.avif'
[21:28:38.291] 
[21:28:38.291] https://nextjs.org/docs/messages/module-not-found
[21:28:38.291] 
[21:28:38.291] Import trace for requested module:
[21:28:38.291] ./src/components/SearchableLayout/index.tsx
[21:28:38.291] ./src/pages/search/index.tsx
[21:28:38.291] 
[21:28:38.291] ./src/constants/carousel.ts
[21:28:38.291] Module not found: Can't resolve '@/assets/mainBanner/mainImage2.avif'
[21:28:38.291] 
[21:28:38.293] https://nextjs.org/docs/messages/module-not-found
[21:28:38.293] 
[21:28:38.293] Import trace for requested module:
[21:28:38.293] ./src/components/SearchableLayout/index.tsx
[21:28:38.293] ./src/pages/search/index.tsx
[21:28:38.293] 
[21:28:38.293] ./src/constants/carousel.ts
[21:28:38.293] Module not found: Can't resolve '@/assets/mainBanner/mainImage3.avif'
[21:28:38.293] 
[21:28:38.293] https://nextjs.org/docs/messages/module-not-found
[21:28:38.293] 
[21:28:38.293] Import trace for requested module:
[21:28:38.293] ./src/components/SearchableLayout/index.tsx
[21:28:38.293] ./src/pages/search/index.tsx
[21:28:38.293] 
[21:28:38.293] 
[21:28:38.293] > Build failed because of webpack errors
[21:28:38.339] Error: Command "npm run build" exited with 1
[21:28:38.743] 
```
