### PR TITLE
[refactor/#168] 리뷰 컴포넌트 개선 및 체험 상세 페이지에 연결

### DIFF
--- a/assets/svgs/altArrowLeft.svg
+++ b/assets/svgs/altArrowLeft.svg
@@ -1,3 +1,3 @@
-<svg width="22" height="21" viewBox="0 0 22 21" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+<svg width="current" height="current" viewBox="0 0 22 21" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
   <path d="M7.4255 10.1759L13.2272 4.54991C13.5892 4.19886 14.2812 4.41165 14.2812 4.87402L14.2812 16.126C14.2812 16.5883 13.5892 16.8011 13.2272 16.4501L7.4255 10.8241C7.23317 10.6376 7.23317 10.3624 7.4255 10.1759Z" fill="currentColor"/>
 </svg>

--- a/assets/svgs/altArrowRight.svg
+++ b/assets/svgs/altArrowRight.svg
@@ -1,3 +1,3 @@
-<svg width="22" height="21" viewBox="0 0 22 21" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+<svg width="current" height="current" viewBox="0 0 22 21" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
 <path d="M14.137 10.1759L8.33534 4.54991C7.97332 4.19886 7.28125 4.41165 7.28125 4.87402L7.28125 16.126C7.28125 16.5883 7.97332 16.8011 8.33534 16.4501L14.137 10.8241C14.3293 10.6376 14.3293 10.3624 14.137 10.1759Z" fill="currentColor"/>
 </svg>

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -2,8 +2,10 @@ import AltArrowLeft from "@/assets/svgs/altArrowLeft.svg";
 import AltArrowRight from "@/assets/svgs/altArrowRight.svg";
 import Button from "@/src/components/Button/Button";
 import Loading from "@/src/components/Loading";
+import useResponsiveTextStyle from "@/src/hooks/Activity/useResponsiveTextStyle";
 import usePagination from "@/src/hooks/usePagination";
 import useLoadingStore from "@/src/stores/loadingStore";
+import { ButtonTextSizeType } from "@/src/types/button";
 import { PaginationProps } from "@/src/types/pagination";
 import clsx from "clsx";
 
@@ -21,27 +23,35 @@ const Pagination = ({
   currentPage,
   itemCountPerPage,
 }: PaginationProps) => {
+  const { isMicroScreen, isExtraXsScreen, isSmallerXsScreen } =
+    useResponsiveTextStyle();
+
+  // border radius
+  const isSmallScreen = isMicroScreen || isExtraXsScreen || isSmallerXsScreen;
+  const radius = isSmallScreen ? "9" : "15";
+
+  // button font style
+  const getFontStyle = (
+    smallScreen: boolean,
+    isActivePage: boolean,
+  ): ButtonTextSizeType => {
+    if (smallScreen) return isActivePage ? "m" : "s";
+    return isActivePage ? "xxxl" : "xxl";
+  };
+
+  const buttonSize = "w-full h-auto max-w-55 max-h-55 aspect-square relative";
+  const iconSize = isSmallScreen ? "15" : "21";
+
   const { start, noPrev, noNext, navigateToPage, totalPages } = usePagination({
     totalItems,
     pageCount,
     currentPage,
     itemCountPerPage,
   });
-  const buttonSize = "size-40 md:size-55";
-  const iconSize = "size-21";
 
   // loading spinner
   const { loadingButtons, showLoadingButtons, hideLoadingButtons } =
     useLoadingStore();
-
-  const handlePageClick = async (pageNumber: number) => {
-    showLoadingButtons(pageNumber);
-    try {
-      await navigateToPage(pageNumber);
-    } finally {
-      hideLoadingButtons(pageNumber);
-    }
-  };
 
   const loadingSpinner = (
     <Loading
@@ -54,74 +64,88 @@ const Pagination = ({
     />
   );
 
+  const handlePageClick = async (pageNumber: number) => {
+    showLoadingButtons(pageNumber);
+    try {
+      await navigateToPage(pageNumber);
+    } finally {
+      hideLoadingButtons(pageNumber);
+    }
+  };
+
   return (
-    <div>
-      <ul className="flex gap-10">
-        <li className={clsx(noPrev)}>
-          <Button
-            type="button"
-            radius="15"
-            gap="10"
-            backgroundColor={noPrev ? "white_gray" : "white_green"}
-            disabled={noPrev}
-            className={clsx(buttonSize, "relative")}
-            onClick={() => handlePageClick(start - 1)}>
-            {loadingButtons?.[start - 1] ? (
-              loadingSpinner
-            ) : (
-              <AltArrowLeft
-                className={clsx(
-                  iconSize,
-                  noPrev ? "text-gray-600" : "text-brand-400",
-                )}
-                aria-label="이전 페이지로 이동 버튼"
-              />
-            )}
-          </Button>
-        </li>
-        {Array.from({ length: pageCount }).map((_, i) => {
-          const pageNumber = start + i;
-          const isActivePage =
-            currentPage === pageNumber || (pageNumber === 1 && !currentPage);
-          return (
-            pageNumber <= totalPages && (
-              <li key={pageNumber}>
-                <Button
-                  type="button"
-                  radius="15"
-                  gap="10"
-                  backgroundColor={isActivePage ? "green" : "white_green"}
-                  fontStyle={isActivePage ? "xxxl" : "xxl"}
-                  disabled={isActivePage}
-                  className={buttonSize}
-                  onClick={() => handlePageClick(pageNumber)}>
-                  {loadingButtons?.[pageNumber] ? loadingSpinner : pageNumber}
-                </Button>
-              </li>
-            )
-          );
-        })}
-        <li>
-          <Button
-            type="button"
-            radius="15"
-            gap="10"
-            backgroundColor={noNext ? "white_gray" : "white_green"}
-            className={buttonSize}
-            disabled={noNext}
-            onClick={() => handlePageClick(start + pageCount)}>
-            {loadingButtons?.[start + pageCount] ? (
-              loadingSpinner
-            ) : (
-              <AltArrowRight
-                className={`${iconSize} ${noNext ? "text-gray-600" : "text-brand-400"}`}
-                aria-label="다음 페이지로 이동 버튼"
-              />
-            )}
-          </Button>
-        </li>
-      </ul>
-    </div>
+    <ul
+      className={clsx(
+        "flex max-h-55 w-full max-w-445 justify-center",
+        isMicroScreen ? "gap-4" : "gap-10",
+      )}>
+      <li className={clsx(noPrev, buttonSize)}>
+        <Button
+          type="button"
+          radius={radius}
+          gap="10"
+          backgroundColor={noPrev ? "white_gray" : "white_green"}
+          disabled={noPrev}
+          className={buttonSize}
+          onClick={() => handlePageClick(start - 1)}>
+          {loadingButtons?.[start - 1] ? (
+            loadingSpinner
+          ) : (
+            <AltArrowLeft
+              width={iconSize}
+              height={iconSize}
+              className={noPrev ? "text-gray-600" : "text-brand-400"}
+              aria-label="이전 페이지로 이동 버튼"
+            />
+          )}
+        </Button>
+      </li>
+      {Array.from({ length: pageCount }).map((_, i) => {
+        const pageNumber = start + i;
+        const isActivePage =
+          currentPage === pageNumber || (pageNumber === 1 && !currentPage);
+        const fontStyle = getFontStyle(isSmallScreen, isActivePage);
+
+        return (
+          pageNumber <= totalPages && (
+            <li key={pageNumber} className={buttonSize}>
+              <Button
+                type="button"
+                radius={radius}
+                gap="10"
+                backgroundColor={isActivePage ? "green" : "white_green"}
+                fontStyle={fontStyle}
+                disabled={isActivePage}
+                className={buttonSize}
+                onClick={() => handlePageClick(pageNumber)}>
+                {loadingButtons?.[pageNumber] ? loadingSpinner : pageNumber}
+              </Button>
+            </li>
+          )
+        );
+      })}
+      <li className={buttonSize}>
+        <Button
+          type="button"
+          radius={radius}
+          gap="10"
+          backgroundColor={noNext ? "white_gray" : "white_green"}
+          className={buttonSize}
+          disabled={noNext}
+          onClick={() => handlePageClick(start + pageCount)}>
+          {loadingButtons?.[start + pageCount] ? (
+            loadingSpinner
+          ) : (
+            <AltArrowRight
+              width={iconSize}
+              height={iconSize}
+              className={noNext ? "text-gray-600" : "text-brand-400"}
+              aria-label="다음 페이지로 이동 버튼"
+            />
+          )}
+        </Button>
+      </li>
+    </ul>
   );
 };
 

--- a/src/components/Review/ProgressBar.tsx
+++ b/src/components/Review/ProgressBar.tsx
@@ -1,5 +1,7 @@
 import PROGRESS_BAR_ITEM from "@/src/constants/progressBar";
+import useResponsiveTextStyle from "@/src/hooks/Activity/useResponsiveTextStyle";
 import { ReviewItem, ReviewSummary } from "@/src/types/review";
+import clsx from "clsx";
 
 const ProgressBar = ({ reviews, totalCount }: ReviewSummary) => {
   const reversedItems = [...PROGRESS_BAR_ITEM].reverse();
@@ -42,13 +44,28 @@ const ProgressBar = ({ reviews, totalCount }: ReviewSummary) => {
     }
   };
 
+  const { isExtraXsScreen } = useResponsiveTextStyle();
+
   return (
-    <section className="flex h-full w-3/5 max-w-600 flex-col items-center justify-evenly p-10 md:px-20 lg:px-30">
+    <section
+      className={clsx(
+        "flex h-full w-3/5 max-w-600 flex-col items-center justify-evenly",
+        isExtraXsScreen ? "px-0 py-10" : "p-10 md:px-20 lg:px-30",
+      )}>
       {reversedItems.map(({ range, title }) => (
         <div
           key={range}
-          className="flex w-full items-center justify-between gap-20 whitespace-nowrap md:gap-30">
-          <p className="font-16px-regular w-74 shrink-0 text-left">{title}</p>
+          className={clsx(
+            "flex w-full items-center justify-between whitespace-nowrap",
+            isExtraXsScreen ? "gap-5" : "gap-20 md:gap-30",
+          )}>
+          <p
+            className={clsx(
+              "w-74 shrink-0 text-left",
+              isExtraXsScreen ? "font-14px-regular" : "font-16px-regular",
+            )}>
+            {title}
+          </p>
           <div className="flex w-full items-center justify-between gap-15 md:gap-20">
             <div className="relative h-17 w-full flex-1 rounded-8 bg-brand-100">
               <div
@@ -58,7 +75,11 @@ const ProgressBar = ({ reviews, totalCount }: ReviewSummary) => {
                 }}
               />
             </div>
-            <p className="font-16px-medium w-10 text-center">
+            <p
+              className={clsx(
+                "w-10 text-center",
+                isExtraXsScreen ? "font-14px-medium" : "font-16px-medium",
+              )}>
               {ratingCounts[range]}
             </p>
           </div>

--- a/src/components/Review/RatingSummary.tsx
+++ b/src/components/Review/RatingSummary.tsx
@@ -1,6 +1,8 @@
 import StarLgIcon from "@/assets/svgs/ic_star_lg.svg";
 import PROGRESS_BAR_ITEM from "@/src/constants/progressBar";
+import useResponsiveTextStyle from "@/src/hooks/Activity/useResponsiveTextStyle";
 import { ReviewItem, ReviewSummary } from "@/src/types/review";
+import clsx from "clsx";
 
 const RatingSummary = ({
   reviews,
@@ -17,7 +19,7 @@ const RatingSummary = ({
 
     const ratingIndex = Math.ceil(rating) - 1;
 
-    return PROGRESS_BAR_ITEM[ratingIndex].title;
+    return PROGRESS_BAR_ITEM[ratingIndex]?.title;
   };
 
   // 만족도 계산
@@ -36,13 +38,34 @@ const RatingSummary = ({
     totalCount,
   );
 
+  // 텍스트스타일
+  const { isMicroScreen, isExtraXsScreen } = useResponsiveTextStyle();
+
   return (
-    <section className="flex h-full w-2/5 flex-col items-center justify-center gap-8 py-10 md:gap-0">
-      <div className="flex flex-row items-center gap-5">
-        <StarLgIcon className="size-39 text-yellow-200 md:size-43" />
+    <section className="flex h-full w-2/5 flex-col items-center justify-center gap-8 overflow-hidden py-10 md:gap-0">
+      <div className="flex items-center gap-5">
+        <StarLgIcon
+          className={clsx(
+            "text-yellow-200 md:size-43",
+            isExtraXsScreen ? "size-27" : "size-39",
+            isMicroScreen && "size-18",
+          )}
+        />
         <div className="flex items-baseline gap-5">
-          <p className="font-44px-bold md:font-50px-bold">{roundedRating}</p>
-          <p className="font-24px-medium md:font-28px-medium text-gray-300">
+          <p
+            className={clsx(
+              "font-44px-bold md:font-50px-bold",
+              isExtraXsScreen && "font-28px-bold",
+              isMicroScreen && "font-20px-bold",
+            )}>
+            {roundedRating}
+          </p>
+          <p
+            className={clsx(
+              "font-24px-medium md:font-28px-medium text-gray-300",
+              isExtraXsScreen && "font-18px-medium",
+              isMicroScreen && "font-16px-medium",
+            )}>
             /5
           </p>
         </div>
@@ -59,7 +82,13 @@ const RatingSummary = ({
         ) : (
           <div />
         )}
-        <p className="font-14px-bold md:font-16px-bold rounded-20 border border-brand-300 bg-brand-200 px-16 py-4 text-brand-500">
+        <p
+          className={clsx(
+            "line-clamp-2 rounded-20 border border-brand-300 bg-brand-200 py-4 text-brand-500",
+            isMicroScreen && isExtraXsScreen
+              ? "font-12px-bold px-8"
+              : "font-14px-bold md:font-16px-bold px-16",
+          )}>
           {satisFactionLevel(roundedRating)}
         </p>
       </div>

--- a/src/components/Review/ReviewList.tsx
+++ b/src/components/Review/ReviewList.tsx
@@ -60,13 +60,7 @@ const ReviewList = ({ fetchedReviews }: ReviewListProps) => {
             </div>
             {idx !== fetchedReviews.length - 1 && (
               <div className="relative">
-                <div
-                  className="absolute left-1/2 h-0.5 border-b border-brand-500 opacity-25 lg:max-w-1200"
-                  style={{
-                    width: "calc(100vw - 17px)",
-                    transform: "translateX(-50%)",
-                  }}
-                />
+                <div className="h-0.5 w-full border-b border-brand-500 opacity-25" />
               </div>
             )}
           </section>

--- a/src/components/Review/index.tsx
+++ b/src/components/Review/index.tsx
@@ -2,46 +2,32 @@ import Pagination from "@/src/components/Pagination";
 import ProgressBar from "@/src/components/Review/ProgressBar";
 import RatingSummary from "@/src/components/Review/RatingSummary";
 import ReviewList from "@/src/components/Review/ReviewList";
-import { getActivityReviews } from "@/src/services/activities";
-import { ReviewSummary } from "@/src/types/review";
+import useReviews from "@/src/hooks/review/useReviews";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
-const Review = ({ reviews, totalCount, averageRating }: ReviewSummary) => {
+const Review = ({ activityId }: { activityId: number }) => {
   const router = useRouter();
-  const searchParams = router.query;
-  const currentPage = Number(searchParams.page) || 1;
-  const [fetchedReviews, setFetchedReviews] = useState([]);
-  const activityId = reviews[0]?.activityId;
+  const { page } = router.query;
+  const currentPage = Number(page) || 1;
   const size = 3;
 
   // 초기 페이지 설정
   useEffect(() => {
-    if (!searchParams.page) {
-      router.replace(`?page=1`);
+    if (!page) {
+      router.replace(`/activity/${activityId}?page=1`);
     }
-  }, [searchParams, router]);
+  }, [activityId, page, router]);
 
-  useEffect(() => {
-    if (totalCount === 0) return;
-
-    const fetchReviews = async () => {
-      try {
-        const page = Number(searchParams.page) || 1;
-
-        const response = await getActivityReviews({ activityId, page, size });
-        setFetchedReviews(response.reviews);
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error(error);
-      }
-    };
-
-    fetchReviews();
-  }, [activityId, reviews, searchParams, size, totalCount]);
+  // data fetching
+  const { reviews, reviewList, totalCount, averageRating } = useReviews({
+    activityId,
+    currentPage,
+    size,
+  });
 
   return (
-    <div className="mx-auto flex max-w-1200 flex-col gap-24">
+    <div className="mx-auto flex flex-col gap-24">
       <header className="flex gap-10">
         <h2 className="font-20px-bold">후기</h2>
         <h2 className="font-20px-bold text-brand-500">{totalCount}</h2>
@@ -55,9 +41,9 @@ const Review = ({ reviews, totalCount, averageRating }: ReviewSummary) => {
         <div className="h-full border-r border-gray-200" />
         <ProgressBar reviews={reviews} totalCount={totalCount} />
       </article>
-      <ReviewList fetchedReviews={fetchedReviews} />
+      <ReviewList fetchedReviews={reviewList} />
       {totalCount > 0 ? (
-        <footer className="mb-120 mt-16 flex justify-center md:mt-66 lg:mt-48">
+        <footer className="mt-16 flex justify-center md:mt-66 lg:mt-48">
           <Pagination
             totalItems={totalCount}
             pageCount={5}

--- a/src/components/Review/index.tsx
+++ b/src/components/Review/index.tsx
@@ -4,20 +4,12 @@ import RatingSummary from "@/src/components/Review/RatingSummary";
 import ReviewList from "@/src/components/Review/ReviewList";
 import useReviews from "@/src/hooks/review/useReviews";
 import { useRouter } from "next/router";
-import { useEffect } from "react";
 
 const Review = ({ activityId }: { activityId: number }) => {
   const router = useRouter();
   const { page } = router.query;
   const currentPage = Number(page) || 1;
   const size = 3;
-
-  // 초기 페이지 설정
-  useEffect(() => {
-    if (!page) {
-      router.replace(`/activity/${activityId}?page=1`);
-    }
-  }, [activityId, page, router]);
 
   // data fetching
   const { reviews, reviewList, totalCount, averageRating } = useReviews({

--- a/src/hooks/review/useReviews.ts
+++ b/src/hooks/review/useReviews.ts
@@ -1,0 +1,66 @@
+/* eslint-disable no-console */
+import { getActivityReviews } from "@/src/services/activities";
+import { UseReviewsProps } from "@/src/types/review";
+import { useEffect, useState } from "react";
+
+const useReviews = ({ activityId, currentPage, size }: UseReviewsProps) => {
+  // RatingSummary, ProgressBar
+  const [reviews, setReviews] = useState([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [averageRating, setAverageRating] = useState(0);
+
+  useEffect(() => {
+    const fetchTotalCount = async () => {
+      try {
+        const response = await getActivityReviews({ activityId });
+        setTotalCount(response.totalCount);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    fetchTotalCount();
+  }, [activityId]);
+
+  useEffect(() => {
+    const fetchReviewSummary = async () => {
+      try {
+        const response = await getActivityReviews({
+          activityId,
+          page: 1,
+          size: totalCount,
+        });
+
+        setReviews(response.reviews);
+        setAverageRating(response.averageRating);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchReviewSummary();
+  }, [activityId, currentPage, totalCount]);
+
+  // ReviewList
+  const [reviewList, setReviewList] = useState([]);
+
+  useEffect(() => {
+    const fetchReviewList = async () => {
+      try {
+        const response = await getActivityReviews({
+          activityId,
+          page: currentPage,
+          size,
+        });
+
+        setReviewList(response.reviews);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    fetchReviewList();
+  }, [activityId, currentPage, size]);
+
+  return { reviews, reviewList, totalCount, averageRating };
+};
+
+export default useReviews;

--- a/src/hooks/review/useReviews.ts
+++ b/src/hooks/review/useReviews.ts
@@ -8,6 +8,8 @@ const useReviews = ({ activityId, currentPage, size }: UseReviewsProps) => {
   const [reviews, setReviews] = useState([]);
   const [totalCount, setTotalCount] = useState(0);
   const [averageRating, setAverageRating] = useState(0);
+  const [fetchError, setFetchError] = useState<Error | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     const fetchTotalCount = async () => {
@@ -38,13 +40,15 @@ const useReviews = ({ activityId, currentPage, size }: UseReviewsProps) => {
     };
 
     fetchReviewSummary();
-  }, [activityId, totalCount]);
+  }, [activityId, currentPage, totalCount]);
 
   // ReviewList
   const [reviewList, setReviewList] = useState([]);
 
   useEffect(() => {
     const fetchReviewList = async () => {
+      setIsLoading(true);
+      setFetchError(null);
       try {
         const response = await getActivityReviews({
           activityId,
@@ -55,12 +59,24 @@ const useReviews = ({ activityId, currentPage, size }: UseReviewsProps) => {
         setReviewList(response.reviews);
       } catch (error) {
         console.error(error);
+        setFetchError(
+          error instanceof Error ? error : new Error("오류가 발생했습니다"),
+        );
+      } finally {
+        setIsLoading(false);
       }
     };
     fetchReviewList();
   }, [activityId, currentPage, size]);
 
-  return { reviews, reviewList, totalCount, averageRating };
+  return {
+    reviews,
+    reviewList,
+    totalCount,
+    averageRating,
+    isLoading,
+    fetchError,
+  };
 };
 
 export default useReviews;

--- a/src/hooks/review/useReviews.ts
+++ b/src/hooks/review/useReviews.ts
@@ -38,7 +38,7 @@ const useReviews = ({ activityId, currentPage, size }: UseReviewsProps) => {
     };
 
     fetchReviewSummary();
-  }, [activityId, currentPage, totalCount]);
+  }, [activityId, totalCount]);
 
   // ReviewList
   const [reviewList, setReviewList] = useState([]);

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -33,7 +33,7 @@ const usePagination = ({
   }, [currentPage, totalPages, router]);
 
   // 페이지 이동
-  const navigateToPage = (page: number) => {
+  const navigateToPage = (page: number): void => {
     const newQuery = { ...router.query, page: String(page) };
     router.push({
       pathname: router.pathname,

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,8 +1,8 @@
-import ButtonProps from "../types/button";
 import lottieJson from "@/assets/json/404.json";
 import AltArrowLeft from "@/assets/svgs/altArrowLeft.svg";
 import AltArrowRight from "@/assets/svgs/altArrowRight.svg";
 import Button from "@/src/components/Button/Button";
+import ButtonProps from "@/src/types/button";
 import { NextPage } from "next";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -30,13 +30,16 @@ const App = ({
 
   const getLayout = Component.getLayout ?? ((page: ReactNode) => page);
 
-  const { pathname } = useRouter();
-
   const { userData, checkAndClearUserData } = useUserStore();
 
+  const { pathname, query } = useRouter();
+
+  const hasQuery = Object.keys(query).length !== 0;
+  const isHome = pathname === "/home" && hasQuery;
+  const isActivityPage = pathname.startsWith("/activity") && hasQuery;
+  const isScrollToTopEnabled = isHome || isActivityPage;
   const isHomeOrSearch = pathname === "/home" || pathname === "/search";
   const is404Page = pageProps?.statusCode === 404;
-  const isActivityPage = pathname.startsWith("/activity");
 
   useEffect(() => {
     if (userData) {
@@ -61,7 +64,7 @@ const App = ({
               ? "bg-brand-50"
               : "h-main bg-gray-50",
           )}>
-          {!(isHomeOrSearch || isActivityPage) && <ScrollToTopHandler />}
+          {!isScrollToTopEnabled && <ScrollToTopHandler />}
           <div
             className={clsx(
               "mx-auto min-h-main",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -34,10 +34,9 @@ const App = ({
 
   const { userData, checkAndClearUserData } = useUserStore();
 
-  const isHomePage = pathname === "/home" || pathname === "/search";
-
-  // 404 page 여부 확인
+  const isHomeOrSearch = pathname === "/home" || pathname === "/search";
   const is404Page = pageProps?.statusCode === 404;
+  const isActivityPage = pathname.startsWith("/activity");
 
   useEffect(() => {
     if (userData) {
@@ -62,11 +61,11 @@ const App = ({
               ? "bg-brand-50"
               : "h-main bg-gray-50",
           )}>
-          <ScrollToTopHandler />
+          {!(isHomeOrSearch || isActivityPage) && <ScrollToTopHandler />}
           <div
             className={clsx(
               "mx-auto min-h-main",
-              !isHomePage && "max-w-screen-xl",
+              !isHomeOrSearch && "max-w-screen-xl",
             )}>
             {getLayout(<Component {...pageProps} />)}
           </div>

--- a/src/pages/activity/[[...activityId]]/index.tsx
+++ b/src/pages/activity/[[...activityId]]/index.tsx
@@ -5,6 +5,7 @@ import ActivityReservationBar from "@/src/components/ActivityReservation/Activit
 import ActivityTitleSection from "@/src/components/ActivityTitleSection";
 import Loading from "@/src/components/Loading";
 import MyActivityHandler from "@/src/components/MyAtivities/MyActivityHandler";
+import Review from "@/src/components/Review";
 import Custom404 from "@/src/pages/404";
 import { useGetActivities } from "@/src/queries/useActivities";
 import useUserStore from "@/src/stores/userStore";
@@ -80,19 +81,8 @@ const ActivitiesPage = () => {
           <ActivityLocation address={address} />
         </ActivityContentSection>
 
-        <ActivityContentSection title="체험 후기">
-          {/* 
-              to. @hayuri1990
-              
-              후기 컴포넌트 렌더링 위치입니다.
-              해당 파일이 아닌 컴포넌트를 따로 생성해주시길 바라며,
-              변수 activityId 를 prop 으로 가져가서 api 요청에 사용하시면 됩니다.
-
-              빈 div 태그 안에 위치한 건 overflow 컨트롤을 위해서 입니다. 작업완료 후 필요에 따라 제거 가능합니다.
-
-              from. @JuhyeokC
-            */}
-          <p>후기 컴포넌트</p>
+        <ActivityContentSection>
+          <Review activityId={Number(activityId)} />
         </ActivityContentSection>
       </div>
 

--- a/src/pages/review/index.tsx
+++ b/src/pages/review/index.tsx
@@ -6,6 +6,12 @@ export const getServerSideProps = async () => {
   const response = await listAllActivities("latest");
   const { activities } = response;
 
+  if (!activities || activities.length === 0) {
+    return {
+      props: { activityId: null },
+    };
+  }
+
   // activityId 랜덤으로 선택
   const randomIndex = Math.floor(Math.random() * activities.length);
   const activityId = activities[randomIndex].id;
@@ -20,7 +26,11 @@ export const getServerSideProps = async () => {
 const ReviewPage = ({
   activityId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  return <Review activityId={activityId} />;
+  return activityId ? (
+    <Review activityId={activityId} />
+  ) : (
+    <div>리뷰를 불러올 수 없습니다.</div>
+  );
 };
 
 export default ReviewPage;

--- a/src/pages/review/index.tsx
+++ b/src/pages/review/index.tsx
@@ -1,46 +1,26 @@
 import Review from "@/src/components/Review";
-import { getActivityReviews } from "@/src/services/activities";
-import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
+import { listAllActivities } from "@/src/services/activities";
+import { InferGetServerSidePropsType } from "next";
 
-export const getServerSideProps = async (
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  context: GetServerSidePropsContext,
-) => {
-  // const {activityId} = context.query;
-  const activityId = 3613; // 임시
-  const reviewInitialData = await getActivityReviews({ activityId });
-  const reviewTotalCount = reviewInitialData.totalCount;
+export const getServerSideProps = async () => {
+  const response = await listAllActivities("latest");
+  const { activities } = response;
 
-  const reviewData = await getActivityReviews({
-    activityId,
-    page: 1,
-    size: reviewTotalCount,
-  });
-
-  const { reviews, totalCount, averageRating } = reviewData;
+  // activityId 랜덤으로 선택
+  const randomIndex = Math.floor(Math.random() * activities.length);
+  const activityId = activities[randomIndex].id;
 
   return {
     props: {
       activityId,
-      reviews,
-      totalCount,
-      averageRating,
     },
   };
 };
 
 const ReviewPage = ({
-  reviews,
-  totalCount,
-  averageRating,
+  activityId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  return (
-    <Review
-      reviews={reviews}
-      totalCount={totalCount}
-      averageRating={averageRating}
-    />
-  );
+  return <Review activityId={activityId} />;
 };
 
 export default ReviewPage;

--- a/src/services/activities.ts
+++ b/src/services/activities.ts
@@ -1,17 +1,17 @@
 /**
  * @description API 호출 함수 - Activites
  */
-import { ActivityDetailResponse } from "@/src/types/activitiesResponses";
 import api from "@/src/services/axios";
 import {
-  ActivityImageUrl,
   ActivitiesResponse,
+  ActivityImageUrl,
   CreateActivityProps,
   CreateActivityReservationProps,
   GetActivityAvailableScheduleProps,
   GetActivityProps,
   GetActivityReviewsProps,
 } from "@/src/types/activities";
+import { ActivityDetailResponse } from "@/src/types/activitiesResponses";
 
 /**
  * @description 모든 체험 리스트 조회
@@ -140,9 +140,11 @@ export const getActivityReviews = async ({
   page,
   size,
 }: GetActivityReviewsProps) => {
-  let url = `/activities/${activityId}/reviews`;
+  let url;
 
-  if (page) {
+  if (!page && !size) {
+    url = `/activities/${activityId}/reviews`;
+  } else {
     url = `/activities/${activityId}/reviews?page=${page}&size=${size}`;
   }
 

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -13,6 +13,7 @@ export interface ReviewItem {
 }
 
 export interface ReviewSummary {
+  activityId?: number;
   reviews: ReviewItem[];
   totalCount: number;
   averageRating?: number;
@@ -20,4 +21,10 @@ export interface ReviewSummary {
 
 export interface ReviewListProps {
   fetchedReviews: ReviewItem[];
+}
+
+export interface UseReviewsProps {
+  activityId: number;
+  currentPage: number;
+  size: number;
 }


### PR DESCRIPTION
# Resolved: #168

## 🔨 작업 내역
- [x] **Pagination 반응형 수정**
- [x] **체험 상세 페이지에 리뷰 컴포넌트 연결**
- [x] **[페이지 내 다른 구분선과 리뷰 컴포넌트 구분선 길이 통일](https://github.com/vivi-trip/vivitrip/commit/0183ddfa17f971a48877b962b83b981f263c562d)**
   - 기존: 피그마 시안에 맞춰 `sm`, `md` 사이즈에서 구분선 여백 없이 표시
     <img src="https://velog.velcdn.com/images/qoswfxin/post/4742b70c-8269-455e-a6ef-170823aee8f1/image.png" width="70%" />
   - 변경: 체험상세 스타일에 맞춰 `sm`, `md` 사이즈에서 main 여백을 제외하고 최대 너비로 지정
     <img src="https://velog.velcdn.com/images/qoswfxin/post/829b9d06-9c46-4d66-a18b-f379cbd38bde/image.png" width="70%" />
- [x] **[리뷰 조회 로직 훅으로 분리, props 구조 개선 및 불필요한 레이아웃 제한 제거](https://github.com/vivi-trip/vivitrip/commit/020d305587eb4fe7303710662c7911df97f23716)**
   - 기존: `pagination`의 `margin-bottom` + `ActivitiesPage` 컴포넌트의 `margin`, `padding` 중복으로 인하여 하단 여백이 너무 크게 설정됨
     <img src="https://velog.velcdn.com/images/qoswfxin/post/35ec21ce-4316-4320-9338-0c76725e01a6/image.png" width="70%" />
   - 변경: `pagination`의 `margin-bottom` 삭제
     <img src="https://velog.velcdn.com/images/qoswfxin/post/12108755-9939-4b89-9c0f-a1a45ab17ce6/image.png" width="70%" />
   - 하단 여백   
     |breakpoint|피그마|현재|
     |:---:|:---:|:---:|
     |`sm`|253px|324px|
     |`md`|265px|332px|
     |`lg`|413px|380px|

<br/>

## ⚒️ 수정 내역
- [x] **[review 예시 페이지 내에서 activityId 랜덤으로 불러오도록 수정](https://github.com/vivi-trip/vivitrip/pull/198/commits/b2020fc83606b7e58655f9a5344205dd89077181)**: 25.03.16.
- [x] **[에러 처리 개선](https://github.com/vivi-trip/vivitrip/pull/198/commits/b360d591806298f1eece9dec04a5b1a60e77f4c1)**: 25.03.16.
- [x] **[메인, 검색, 체험 상세 페이지에서 새로고침 시 스크롤이 최상단으로 이동하는 문제 해결](https://github.com/vivi-trip/vivitrip/pull/198/commits/bded1687c20df483aa8a9ccd17a176f18d2c1a73)**: 25.03.19.
- [x] **[체험 상세 페이지에서 쿼리 파라미터 초기화 제거 및 쿼리 파라미터가 있을 때 메인과 체험 상세 페이지에서 ScrollToTopHandler가 실행되지 않도록 수정](https://github.com/vivi-trip/vivitrip/pull/198/commits/40e007f875a98e575db2b261f12fc34eadc5f06d)**: 25.03.19.
  

<br/>

## 🔊 전달 사항

- @JuhyeokC @kanghyosung1
  간혹 체험 상세 페이지에 접근 시, `activityId`가 NaN이 되어 콘솔에 경고가 발생합니다.
  ![image](https://github.com/user-attachments/assets/33beed29-4ec1-4750-94c3-89844efdf655)
  그에 따라 아래 콘솔 경고가 발생합니다.
  ![image](https://github.com/user-attachments/assets/6563d4c7-4c7e-4de4-a42c-e2310f5c0c47)
  이 부분 확인 부탁 드립니다.

<br/>

## 👩‍🔧 오류 내역
- [x] **review 예시 페이지로 인한 build 에러 해결**
  <img src="https://github.com/user-attachments/assets/61a38411-e7a6-4840-9b6d-e414dc5d41b2" width="70%" />

<br/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 활동 상세 페이지에 리뷰 섹션이 직접 통합되어 사용자 리뷰 확인이 용이해졌습니다.

- **스타일**
  - 다양한 화면 크기에 맞게 버튼, 폰트, 간격 등의 UI 스타일이 동적으로 조정되어 반응형 디자인이 강화되었습니다.

- **리팩토링**
  - 리뷰와 페이지네이션 처리 로직이 간소화되어 데이터 로딩과 UI 렌더링이 더욱 원활해졌습니다.

- **버그 수정**
  - 리뷰 컴포넌트의 오류 처리 및 조건부 스타일링이 개선되어 사용자 경험이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->