### PR TITLE
[fix/#204] 예약 확인 페이지 텍스트 수정

### DIFF
--- a/src/components/MyAtivities/ActivityCard.tsx
+++ b/src/components/MyAtivities/ActivityCard.tsx
@@ -68,7 +68,14 @@ const ActivitiesCard = ({ activity }: ActivitiesCardProps) => {
               </span>
             </div>
             <div className="flex h-full flex-col items-start justify-between">
-              <p className="font-14px-bold md:font-20px-bold">{title}</p>
+              <p  className={clsx(
+              "font-14px-bold text-left",
+              "w-full max-w-200 truncate",
+              "md:font-18px-bold md:max-w-300",
+              "lg:font-20px-bold lg:mt-8 lg:max-w-480",
+            )}>
+                {title}
+              </p>
               <div className="flex w-full items-center justify-between">
                 <p className="font-16px-medium md:font-20px-medium lg:font-24px-medium lg:text-gray-700">
                   ₩{price?.toLocaleString("ko-KR")} /인

--- a/src/components/MyReservations/ReservationCard.tsx
+++ b/src/components/MyReservations/ReservationCard.tsx
@@ -78,8 +78,8 @@ const ReservationCard = ({ reservation }: ReservationCardProps) => {
   return (
     <div
       className={clsx(
-        "mb-8 h-128 w-full min-w-280 rounded-24 border border-white",
-        "md:mb-16 md:h-156",
+        "mb-8 h-128 w-full min-w-300 rounded-24 border border-white",
+        "md:mb-16 md:h-156 md:min-w-540",
         "lg:mb-24 lg:h-204",
       )}
       style={{ boxShadow: "0px 4px 16px 0px rgba(0, 0, 0, 0.08)" }}>
@@ -117,8 +117,9 @@ const ReservationCard = ({ reservation }: ReservationCardProps) => {
           <span
             className={clsx(
               "font-14px-bold text-left",
-              "md:font-18px-bold",
-              "lg:font-20px-bold lg:mt-8",
+              "w-full max-w-200 truncate",
+              "md:font-18px-bold md:max-w-300",
+              "lg:font-20px-bold lg:mt-8 lg:max-w-480",
             )}>
             {title}
           </span>

--- a/src/components/modal/TwoButtonModal.tsx
+++ b/src/components/modal/TwoButtonModal.tsx
@@ -24,7 +24,7 @@ const TwoButtonModal = ({
   const { setModalClose } = useModalStore();
 
   return (
-    <div className="flex h-184 w-298 flex-col rounded-12">
+    <div className="flex h-184 mt-300 md:mt-auto mx-auto w-298 flex-col rounded-12 ">
       <div className="mt-24 flex justify-center">
         <CheckIcon />
       </div>


### PR DESCRIPTION
# Resolved: #204 


## 🔨 작업내역
[x] 예약페이지 카드 텍스트 넘어가는 부분 수정
[x] 내체험 카드 텍스트 넘어가는 부분 수정
[x] 투버튼 모달 모바일 사이즈 여백 일부 수정


## 🔊 전달사항

- 체험 등록&수정  스케줄 등록 부분  시작 시간 등록 시 종료 시간 한 시간 단위로 되어 있는 부분을  원하는 시간으로 설정 하게 수정을 2일 동안  시도  해보았지만  실패 했습니다. 😂😂😂😂😂😂    
-  문제 되는 부분이  시작   오전  3시부터     오후  22시로    등록 했다면  다음 번   스케줄 선택 시  시작 시간은 필터가 되어   시작 가능한  오전 0~2시     오후 22시~23  필터 된 값이  나옵니다 다만  문제의 종료 시간인데   시작 시간을   오전   1시로 선택을 하면   종료 시간은 2~3시 값만 나와야 합니다.   하지만   2~3시   22~23시가 나옵니다. 이렇게 되면    22시 또는 23시를 선택하면  오전 1시~ 23시가 되어 버리기 때문에 첫 번째 스케줄과 중복이 되어 문제가 발생 됩니다.    이걸......   여러 시도를 해봤는데 하나가 해결되면 하나가 꼬이고 하기 때문에..... 현재로서는  제 실력으론  수정 전까지 결과물이 최선입니다.  하하하......   


## 🎨 예시이미지

- 
![Uploading 20250319_054028.pn
![20250319_054042](https://github.com/user-attachments/assets/5e68035a-c2f1-47ce-b221-97807e0662ea)
g…]()
![20250319_054106](https://github.com/user-attachments/assets/00977274-9956-4c3d-8688-d660336d89a3)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- **Activity 카드**: 제목 스타일과 레이아웃을 업데이트해 다양한 화면 크기에 최적화된 디자인을 제공합니다.
	- **예약 카드**: 최소 및 최대 너비 조정을 통해 보다 자연스럽고 일관된 레이아웃 구현.
	- **2버튼 모달**: 중앙 정렬과 마진 조정을 개선하여 깔끔한 사용자 인터페이스를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->