### PR TITLE
[fix/#234] 쿼리 확인 시 activityId 키 제외 필터 추가

### DIFF
--- a/src/components/ScrollHandler/ScrollToTopHandler.tsx
+++ b/src/components/ScrollHandler/ScrollToTopHandler.tsx
@@ -7,11 +7,9 @@ const ScrollToTopHandler = () => {
   const { handleScrollToTop } = useScroll();
 
   useEffect(() => {
-    const handleRouteChange = () => handleScrollToTop();
-
-    router.events.on("routeChangeComplete", handleRouteChange);
+    router.events.on("routeChangeComplete", handleScrollToTop);
     return () => {
-      router.events.off("routeChangeComplete", handleRouteChange);
+      router.events.off("routeChangeComplete", handleScrollToTop);
     };
   }, [router, handleScrollToTop]);
 

--- a/src/contexts/ScrollContext.tsx
+++ b/src/contexts/ScrollContext.tsx
@@ -1,8 +1,19 @@
 import { ComponentProps } from "@/src/types/type";
 import clsx from "clsx";
-import { createContext, useCallback, useContext, useMemo, useRef } from "react";
+import { useRouter } from "next/router";
+import {
+  Dispatch,
+  SetStateAction,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 interface ScrollContextProps {
+  scrollBlock: Dispatch<SetStateAction<boolean>>;
   handleScrollToTop: () => void;
 }
 
@@ -18,16 +29,27 @@ const ScrollProvider = ({
   as: Component = "div",
 }: ScrollProviderProps) => {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const router = useRouter();
+  const { query } = router;
+  const hasQuery =
+    Object.keys(query).filter((key) => key === "page" || key === "category")
+      .length > 0;
+
+  const [scrollBlock, setScrollBlock] = useState<boolean>(false);
 
   const handleScrollToTop = useCallback(() => {
+    if (hasQuery || scrollBlock) {
+      return;
+    }
+
     if (scrollRef.current) {
       scrollRef.current.scrollTo({ top: 0, behavior: "instant" });
     }
-  }, []);
+  }, [hasQuery, scrollBlock]);
 
   const contextValue = useMemo(
-    () => ({ handleScrollToTop }),
-    [handleScrollToTop],
+    () => ({ scrollBlock: setScrollBlock, handleScrollToTop }),
+    [setScrollBlock, handleScrollToTop],
   );
 
   return (

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,3 +1,4 @@
+import { useScroll } from "../contexts/ScrollContext";
 import { PaginationProps } from "@/src/types/pagination";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -13,6 +14,7 @@ const usePagination = ({
   const [start, setStart] = useState(1);
   const noPrev = start === 1;
   const noNext = start + pageCount - 1 >= totalPages;
+  const { scrollBlock } = useScroll();
 
   // 현재 페이지에 맞춰 시작 페이지(start) 계산
   useEffect(() => {
@@ -34,11 +36,16 @@ const usePagination = ({
 
   // 페이지 이동
   const navigateToPage = (page: number): void => {
+    scrollBlock(true);
     const newQuery = { ...router.query, page: String(page) };
-    router.push({
-      pathname: router.pathname,
-      query: newQuery,
-    });
+    router
+      .push({
+        pathname: router.pathname,
+        query: newQuery,
+      })
+      .finally(() => {
+        scrollBlock(false);
+      });
   };
 
   return {

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,4 +1,4 @@
-import { useScroll } from "../contexts/ScrollContext";
+import { useScroll } from "@/src/contexts/ScrollContext";
 import { PaginationProps } from "@/src/types/pagination";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -34,7 +34,8 @@ const App = ({
 
   const { pathname, query } = useRouter();
 
-  const hasQuery = Object.keys(query).length !== 0;
+  const hasQuery =
+    Object.keys(query).filter((key) => key !== "activityId").length !== 0;
   const isHome = pathname === "/home" && hasQuery;
   const isActivityPage = pathname.startsWith("/activity") && hasQuery;
   const isScrollToTopEnabled = isHome || isActivityPage;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -32,13 +32,8 @@ const App = ({
 
   const { userData, checkAndClearUserData } = useUserStore();
 
-  const { pathname, query } = useRouter();
+  const { pathname } = useRouter();
 
-  const hasQuery =
-    Object.keys(query).filter((key) => key !== "activityId").length !== 0;
-  const isHome = pathname === "/home" && hasQuery;
-  const isActivityPage = pathname.startsWith("/activity") && hasQuery;
-  const isScrollToTopEnabled = isHome || isActivityPage;
   const isHomeOrSearch = pathname === "/home" || pathname === "/search";
   const is404Page = pageProps?.statusCode === 404;
 
@@ -88,7 +83,7 @@ const App = ({
                 ? "bg-brand-50"
                 : "h-main bg-gray-50",
             )}>
-            {!isScrollToTopEnabled && <ScrollToTopHandler />}
+            <ScrollToTopHandler />
             <div
               className={clsx(
                 "mx-auto min-h-main",

--- a/src/utils/downloadThumbnail.ts
+++ b/src/utils/downloadThumbnail.ts
@@ -60,7 +60,6 @@ const downloadThumbnail = async ({
     // 업로드 전에 파일이 이미 존재하는지 확인
     const existingFileUrl = await checkIfFileExists(fileName);
     if (existingFileUrl) {
-      console.log("파일이 이미 존재합니다.");
       return; // 파일이 존재하면 얼리 리턴
     }
 


### PR DESCRIPTION
# Resolved: #234 

## 🔨 작업내역

- 쿼리 키 확인 시 필터로 `activityId` 를 제외합니다.

## 🔊 전달사항

- 이제 체험 상세페이지 접근 시 항상 스크롤이 맨 위에서 시작합니다!

## 📌 이슈사항

- 이슈내용

## 👩‍🔧 오류내역

- 오류내용

## 🎨 예시이미지

- 예시이미지 첨부


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **리팩터**
	- URL 쿼리 파라미터 처리 방식을 개선해, 불필요한 파라미터가 페이지 선택에 영향을 주지 않도록 수정했습니다.
	- 스크롤 이동 처리 로직을 간소화하여 코드의 명확성과 간결성을 향상시켰습니다.
	- 스크롤 상태 관리를 위한 새로운 상태 변수를 추가하여 스크롤 동작을 제어할 수 있도록 했습니다.
	- 페이지 탐색 시 스크롤 차단 및 해제를 통해 사용자 경험을 개선했습니다.
- **버그 수정**
	- `downloadThumbnail` 함수에서 불필요한 콘솔 로그를 제거했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->