### PR TITLE
[fix/#236] 체험 내용 줄바꿈 허용 및 수정/등록시 모달 추가

### DIFF
--- a/src/components/ActivityInput/ActivityTextArea.tsx
+++ b/src/components/ActivityInput/ActivityTextArea.tsx
@@ -16,7 +16,7 @@ const ActivityTextArea = ({ control }: TextAreaProps) => {
         rules={{
           required: { value: true, message: "필수 입력 값입니다." },
           pattern: {
-            value: /^[^\n]+$/,
+            value: /^[\s\S]*$/,
             message: "문자열을 포함하여 작성해주세요.",
           },
         }}

--- a/src/components/Modal/PopupModal.tsx
+++ b/src/components/Modal/PopupModal.tsx
@@ -6,10 +6,20 @@ import React from "react";
 interface PopupModalProps {
   title: string;
   content?: string;
+  onConfirm?: () => void;
 }
 
-const PopupModal = ({ title, content }: PopupModalProps): JSX.Element => {
+const PopupModal = ({
+  title,
+  content,
+  onConfirm,
+}: PopupModalProps): JSX.Element => {
   const { setModalClose } = useModalStore();
+
+  const handleConfirm = () => {
+    setModalClose();
+    onConfirm?.();
+  };
 
   return (
     <div
@@ -47,7 +57,7 @@ const PopupModal = ({ title, content }: PopupModalProps): JSX.Element => {
         backgroundColor="black"
         radius="8"
         gap="8"
-        onClick={setModalClose}>
+        onClick={handleConfirm }>
         확인
       </Button>
     </div>

--- a/src/components/Modal/PopupModal.tsx
+++ b/src/components/Modal/PopupModal.tsx
@@ -57,7 +57,7 @@ const PopupModal = ({
         backgroundColor="black"
         radius="8"
         gap="8"
-        onClick={handleConfirm }>
+        onClick={handleConfirm}>
         확인
       </Button>
     </div>

--- a/src/components/MyActivities/ActivityConservation.tsx
+++ b/src/components/MyActivities/ActivityConservation.tsx
@@ -70,7 +70,17 @@ const ActivityConservation = ({ activityId }: RegisterPageProps) => {
 
     createActivity(requestData, {
       onSuccess: () => {
-        router.push(PATH_NAMES.MyActivities);
+        setModalOpen(
+          <PopupModal
+            title="체험이 등록되었습니다."
+            onConfirm ={() => {
+              router.push(PATH_NAMES.MyActivities);
+            }}
+          />,
+          {
+            customClass: "md:p-32",
+          },
+        );
       },
     });
   };

--- a/src/components/MyActivities/ActivityConservation.tsx
+++ b/src/components/MyActivities/ActivityConservation.tsx
@@ -6,6 +6,7 @@ import ActivityTextArea from "@/src/components/ActivityInput/ActivityTextArea";
 import ActivityTimeInput from "@/src/components/ActivityInput/ActivityTimeInput";
 import ActivityTitleInput from "@/src/components/ActivityInput/ActivityTitleInput";
 import Button from "@/src/components/Button/Button";
+import PopupModal from "@/src/components/Modal/PopupModal";
 import TwoButtonModal from "@/src/components/Modal/TwoButtonModal";
 import PATH_NAMES from "@/src/constants/pathname";
 import {
@@ -171,7 +172,17 @@ const ActivityConservation = ({ activityId }: RegisterPageProps) => {
         },
         {
           onSuccess: () => {
-            router.push(PATH_NAMES.MyActivities);
+            setModalOpen(
+              <PopupModal
+                title="체험이 수정되었습니다."
+                onConfirm ={() => {
+                  router.push(PATH_NAMES.MyActivities);
+                }}
+              />,
+              {
+                customClass: "md:p-32",
+              },
+            );
           },
         },
       );

--- a/src/pages/activity/[[...activityId]]/index.tsx
+++ b/src/pages/activity/[[...activityId]]/index.tsx
@@ -145,7 +145,9 @@ const ActivitiesPage = ({ post }: { post: ActivityDetailResponse }) => {
         />
 
         <ActivityContentSection title="체험 설명">
-          <p className="font-16px-regular mt-16">{description}</p>
+          <p className="font-16px-regular mt-16 whitespace-pre">
+            {description}
+          </p>
         </ActivityContentSection>
 
         <ActivityContentSection title="체험 장소">


### PR DESCRIPTION
# Resolved: #236 

## 🔨 작업내역

- 체험 수정/등록 시 줄바꿈 허용 
- 체험 수정/등록 버튼 클릭시 모달창 오픈

## 🎨 예시이미지

![20250326_173103](https://github.com/user-attachments/assets/923118be-9d41-4c06-8884-0e2c851c2ecd)
![20250326_173110](https://github.com/user-attachments/assets/2ae95411-2192-4a9d-a15b-940fce5f464a)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 텍스트 입력 필드의 유효성 검사 규칙이 개선되어 공백 및 줄바꿈이 포함된 입력을 허용합니다.
	- 확인 버튼 클릭 시 추가 동작을 수행할 수 있는 옵션이 있는 모달 대화상자가 도입되었습니다.
	- 활동 업데이트 후 즉시 이동 대신 확인 메시지를 통해 사용자에게 업데이트 사실을 안내합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->