### PR TITLE
[feat/#243] 모달 컴포넌트 적용, 체험 예약 세부 수정

### DIFF
--- a/src/components/Modal/PopupModal.tsx
+++ b/src/components/Modal/PopupModal.tsx
@@ -2,9 +2,10 @@ import Button from "@/src/components/Button/Button";
 import useModalStore from "@/src/stores/useModalStore";
 import clsx from "clsx";
 import React from "react";
+import type { ReactNode } from "react";
 
 interface PopupModalProps {
-  title: string;
+  title: string | ReactNode;
   content?: string;
 }
 

--- a/src/components/Modal/ReviewModal/Common/ReviewForm.tsx
+++ b/src/components/Modal/ReviewModal/Common/ReviewForm.tsx
@@ -13,7 +13,7 @@ interface ReviewFromProps {
 }
 
 const ReviewForm = ({ reservationId }: ReviewFromProps) => {
-  const [rating, setRating] = useState<ReservationRating>(0);
+  const [rating, setRating] = useState<ReservationRating>(1);
   const [reviewText, setReviewText] = useState("");
   const { setModalOpen } = useModalStore();
 
@@ -28,8 +28,8 @@ const ReviewForm = ({ reservationId }: ReviewFromProps) => {
   const handleStars = (clicked: ReservationRating) => {
     if (rating === clicked) {
       // 동일한 별점을 다시 클릭하면 하나 줄어든 값으로 설정
-      const newRating = clicked - 1;
-      setRating(newRating as ReservationRating); // 최소값은 0으로 유지
+      const newRating = clicked > 1 ? clicked - 1 : 1; // 최소값은 1으로 유지
+      setRating(newRating as ReservationRating);
     } else {
       // 다른 별점을 클릭하면 해당 값으로 설정
       setRating(clicked);
@@ -45,7 +45,7 @@ const ReviewForm = ({ reservationId }: ReviewFromProps) => {
       onSuccess: () => {
         setModalOpen(<PopupModal title="리뷰가 등록 되었습니다." />);
         setReviewText("");
-        setRating(0);
+        setRating(1);
       },
       onError: (error) => {
         if (error instanceof AxiosError && error.response) {
@@ -71,7 +71,7 @@ const ReviewForm = ({ reservationId }: ReviewFromProps) => {
             role="button"
             className="cursor-pointer">
             {rating !== null && id <= rating ? (
-              <IconStar className="size-60 text-yellow-400" />
+              <IconStar className="size-50 text-yellow-400" />
             ) : (
               <IconStar className="size-50 stroke-gray-400 text-transparent" />
             )}

--- a/src/components/Modal/TwoButtonModal.tsx
+++ b/src/components/Modal/TwoButtonModal.tsx
@@ -2,10 +2,11 @@ import CheckIcon from "@/assets/svgs/ic_check.svg";
 import Button from "@/src/components/Button/Button";
 import useModalStore from "@/src/stores/useModalStore";
 import React from "react";
+import type { ReactNode } from "react";
 
 interface CancelModalProps {
   onCancel: () => void;
-  title: string;
+  title: string | ReactNode;
   negativeContent: string;
   interactiveContent: string;
 }

--- a/src/components/MyActivities/ActivityCard.tsx
+++ b/src/components/MyActivities/ActivityCard.tsx
@@ -29,7 +29,7 @@ const ActivitiesCard = ({ activity }: ActivitiesCardProps) => {
       href={`${PATH_NAMES.Activity}/${activityId}`}
       className={clsx(
         "relative flex",
-        "rounded-24 border border-white shadow-[0px_4px_16px_0px_rgba(0,0,0,0.08)]",
+        "rounded-24 bg-white shadow-[0px_4px_16px_0px_rgba(0,0,0,0.08)]",
         "mt-24 h-128 w-full min-w-280",
         "md:h-156",
         "lg:h-204",
@@ -46,7 +46,7 @@ const ActivitiesCard = ({ activity }: ActivitiesCardProps) => {
           src={bannerImageUrl}
           alt="체험 이미지"
           fill
-          className="border border-brand-200 bg-brand-400 object-cover"
+          className="bg-brand-400 object-cover"
         />
       </div>
       <div

--- a/src/components/MyActivities/ActivityConservation.tsx
+++ b/src/components/MyActivities/ActivityConservation.tsx
@@ -14,8 +14,8 @@ import {
   usePatchMyActivity,
 } from "@/src/queries/useActivities";
 import useModalStore from "@/src/stores/useModalStore";
-import { ActivityUpdateRequest } from "@/src/types/activitiesReservationType";
-import { ActivityFormDataType } from "@/src/types/activityFormDataType";
+import type { ActivityUpdateRequest } from "@/src/types/activitiesReservationType";
+import type { ActivityFormDataType } from "@/src/types/activityFormDataType";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { useFieldArray, useForm } from "react-hook-form";

--- a/src/components/MyPage/index.tsx
+++ b/src/components/MyPage/index.tsx
@@ -1,4 +1,6 @@
+import TwoButtonModal from "../Modal/TwoButtonModal";
 import Form from "@/src/components/Form";
+import useModalStore from "@/src/stores/useModalStore";
 import useUserStore from "@/src/stores/useUserStore";
 import type { ComponentProps } from "@/src/types/type";
 import type { MyPageProps, UserPatchProps } from "@/src/types/user";
@@ -9,12 +11,27 @@ const MyPage = ({
   children,
 }: MyPageProps & ComponentProps) => {
   const { userData } = useUserStore();
+  const { setModalOpen, setModalClose } = useModalStore();
+
+  const handleUserUpdateConfirm = async (formData: UserPatchProps) => {
+    setModalOpen(
+      <TwoButtonModal
+        onCancel={() => {
+          handleSubmit(formData);
+          setModalClose();
+        }}
+        title="내정보를 수정하시겠습니까?"
+        negativeContent="취소"
+        interactiveContent="확인"
+      />,
+    );
+  };
 
   if (!userData) return null;
 
   return (
     <Form
-      onSubmit={handleSubmit}
+      onSubmit={handleUserUpdateConfirm}
       className="mx-auto w-full max-w-640 pb-48 md:ml-0">
       <Form.Title>내정보</Form.Title>
 

--- a/src/components/MyPage/index.tsx
+++ b/src/components/MyPage/index.tsx
@@ -1,7 +1,7 @@
 import Form from "@/src/components/Form";
 import useUserStore from "@/src/stores/useUserStore";
-import { ComponentProps } from "@/src/types/type";
-import { MyPageProps } from "@/src/types/user";
+import type { ComponentProps } from "@/src/types/type";
+import type { MyPageProps, UserPatchProps } from "@/src/types/user";
 
 const MyPage = ({
   handleSubmit,

--- a/src/components/MyReservations/ReservationCard.tsx
+++ b/src/components/MyReservations/ReservationCard.tsx
@@ -83,7 +83,7 @@ const ReservationCard = ({ reservation }: ReservationCardProps) => {
   return (
     <div
       className={clsx(
-        "mb-8 h-128 w-full min-w-300 rounded-24 border border-white",
+        "mb-8 h-128 w-full min-w-300 rounded-24 bg-white",
         "md:mb-16 md:h-156 md:min-w-540",
         "lg:mb-24 lg:h-204",
       )}
@@ -95,14 +95,14 @@ const ReservationCard = ({ reservation }: ReservationCardProps) => {
             "h-128 min-w-128",
             "md:h-156 md:min-w-156",
             "lg:h-204 lg:min-w-204",
-            "lg:font-20px-bold lg:mt-8 lg:max-w-480",
+            "lg:font-20px-bold lg:max-w-480",
           )}>
           <Image
             src={bannerImageUrl}
             alt="체험이미지"
             fill
             style={{ objectFit: "cover" }}
-            className="rounded-l-24 border border-brand-200 bg-brand-400"
+            className="rounded-l-24 bg-brand-400"
           />
         </div>
         <div

--- a/src/components/MyReservations/ReservationCard.tsx
+++ b/src/components/MyReservations/ReservationCard.tsx
@@ -1,6 +1,7 @@
 import Button from "@/src/components/Button/Button";
 import PopupModal from "@/src/components/Modal/PopupModal";
 import ReviewModal from "@/src/components/Modal/ReviewModal/ReviewModal";
+import PATH_NAMES from "@/src/constants/pathname";
 import RESERVATION_LABEL from "@/src/constants/reservationStatus";
 import { usePatchMyReservation } from "@/src/queries/useMyReservations";
 import useModalStore from "@/src/stores/useModalStore";
@@ -8,6 +9,7 @@ import { Reservation } from "@/src/types/myReservationsResponses";
 import { formatDate3 } from "@/src/utils/calendarFormatDate";
 import clsx from "clsx";
 import Image from "next/image";
+import Link from "next/link";
 
 /**
  * @description 내 예약 내용
@@ -43,7 +45,7 @@ const ReservationCard = ({ reservation }: ReservationCardProps) => {
     id,
   } = reservation;
 
-  const { bannerImageUrl, title } = activity;
+  const { id: activityId, bannerImageUrl, title } = activity;
 
   const reviewData = {
     bannerImageUrl,
@@ -81,8 +83,10 @@ const ReservationCard = ({ reservation }: ReservationCardProps) => {
     "text-gray-500";
 
   return (
-    <div
+    <Link
+      href={`${PATH_NAMES.Activity}/${activityId}`}
       className={clsx(
+        "block",
         "mb-8 h-128 w-full min-w-300 rounded-24 bg-white",
         "md:mb-16 md:h-156 md:min-w-540",
         "lg:mb-24 lg:h-204",
@@ -187,7 +191,7 @@ const ReservationCard = ({ reservation }: ReservationCardProps) => {
           </div>
         </div>
       </div>
-    </div>
+    </Link>
   );
 };
 

--- a/src/components/MyReservations/ReservationStatusDropdown.tsx
+++ b/src/components/MyReservations/ReservationStatusDropdown.tsx
@@ -43,7 +43,7 @@ const ReservationStatusDropdown = ({
           className={clsx(
             "h-44 min-w-120 px-12 py-10",
             "md:h-56 md:px-16 md:py-15 lg:w-160",
-            "rounded-15 border border-brand-400",
+            "rounded-15 border border-brand-400 bg-white",
             "flex justify-between",
           )}
           onClick={() => setIsOpen((prev) => !prev)}>

--- a/src/components/SideNavigationMenu/SideNavigationMenu.tsx
+++ b/src/components/SideNavigationMenu/SideNavigationMenu.tsx
@@ -55,7 +55,7 @@ const SideNavigationMenu = ({ canChangeProfile }: Props) => {
     {
       icon: CalendarCheckIcon,
       alt: "예약현황 아이콘",
-      label: "예약 현황",
+      label: "내 체험 예약 현황",
       path: "/reservation-history",
       id: 4,
     },

--- a/src/components/UserProfile/index.tsx
+++ b/src/components/UserProfile/index.tsx
@@ -44,7 +44,7 @@ const UserProfile = () => {
     {
       id: "ReservationHistory",
       icon: <CalendarCheckIcon viewBox="0 0 24 24" width={16} height={16} />,
-      name: "예약 현황",
+      name: "내 체험 예약 현황",
       handleClick: () => router.push(PATH_NAMES.ReservationHistory),
     },
     {

--- a/src/constants/testUsers.ts
+++ b/src/constants/testUsers.ts
@@ -34,6 +34,11 @@ const TEST_USERS: TestUserProps[] = [
     password: "hi@yu.ri",
   },
   {
+    nickname: "LEE",
+    email: "lee@test.com",
+    password: "!ASDF12345",
+  },
+  {
     nickname: "초이주혁",
     email: "choi@ju.hyeok",
     password: "QWER123$",

--- a/src/constants/testUsers.ts
+++ b/src/constants/testUsers.ts
@@ -39,6 +39,16 @@ const TEST_USERS: TestUserProps[] = [
     password: "QWER123$",
   },
   {
+    nickname: "jhchoi.net",
+    email: "test@jhchoi.net",
+    password: "!@#$QWER",
+  },
+  {
+    nickname: "choi.net",
+    email: "juhyeok@choi.net",
+    password: "!@#$QWER",
+  },
+  {
     nickname: "체험테스트",
     email: "123123123@naver.com",
     password: "123123123Z!",

--- a/src/containers/MyPageWrap/index.tsx
+++ b/src/containers/MyPageWrap/index.tsx
@@ -1,0 +1,16 @@
+import { ComponentProps } from "@/src/types/type";
+import clsx from "clsx";
+
+const MyPageWrap = ({ className, children }: ComponentProps) => {
+  return (
+    <div
+      className={clsx(
+        "flex w-full justify-center gap-24 pb-120 pt-72",
+        className,
+      )}>
+      {children}
+    </div>
+  );
+};
+
+export default MyPageWrap;

--- a/src/pages/my-activities/index.tsx
+++ b/src/pages/my-activities/index.tsx
@@ -2,6 +2,7 @@ import Button from "@/src/components/Button/Button";
 import ActivityList from "@/src/components/MyActivities/ActivityList";
 import SideNavigationMenu from "@/src/components/SideNavigationMenu/SideNavigationMenu";
 import PATH_NAMES from "@/src/constants/pathname";
+import MyPageWrap from "@/src/containers/MyPageWrap";
 import { useRouter } from "next/router";
 
 const MyActivities = () => {
@@ -12,7 +13,7 @@ const MyActivities = () => {
   };
 
   return (
-    <div className="flex w-full justify-center gap-24 pt-72">
+    <MyPageWrap>
       <SideNavigationMenu />
       <div className="flex-1">
         <div className="flex justify-between">
@@ -31,7 +32,7 @@ const MyActivities = () => {
         </div>
         <ActivityList />
       </div>
-    </div>
+    </MyPageWrap>
   );
 };
 

--- a/src/pages/my-page/index.tsx
+++ b/src/pages/my-page/index.tsx
@@ -5,6 +5,7 @@ import MyPageKakao from "@/src/components/MyPage/kakao";
 import ProfileUpload from "@/src/components/SideNavigationMenu/Common/ProfileUpload";
 import SideNavigationMenu from "@/src/components/SideNavigationMenu/SideNavigationMenu";
 import PATH_NAMES from "@/src/constants/pathname";
+import MyPageWrap from "@/src/containers/MyPageWrap";
 import useHydration from "@/src/hooks/useHydration";
 import { useUpdateMyData } from "@/src/queries/auth";
 import useModalStore from "@/src/stores/useModalStore";
@@ -74,19 +75,19 @@ const RouteMyPage = () => {
     }
     case "kakao": {
       return (
-        <div className="flex w-full justify-center gap-24 pt-72">
+        <MyPageWrap>
           <div className="hidden md:block">
             <SideNavigationMenu />
           </div>
           <div className="flex-1">
             <MyPageKakao />
           </div>
-        </div>
+        </MyPageWrap>
       );
     }
     default: {
       return (
-        <div className="flex w-full justify-center gap-24 pt-72">
+        <MyPageWrap>
           <div className="hidden md:block">
             <SideNavigationMenu canChangeProfile />
           </div>
@@ -97,7 +98,7 @@ const RouteMyPage = () => {
               </div>
             </MyPage>
           </div>
-        </div>
+        </MyPageWrap>
       );
     }
   }

--- a/src/pages/my-reservations/index.tsx
+++ b/src/pages/my-reservations/index.tsx
@@ -1,6 +1,7 @@
 import ReservationList from "@/src/components/MyReservations/ReservationList";
 import ReservationStatusDropdown from "@/src/components/MyReservations/ReservationStatusDropdown";
 import SideNavigationMenu from "@/src/components/SideNavigationMenu/SideNavigationMenu";
+import MyPageWrap from "@/src/containers/MyPageWrap";
 import { ReservationStatus } from "@/src/types/myReservations";
 import { useState } from "react";
 
@@ -12,22 +13,18 @@ const MyReservations = () => {
   };
 
   return (
-    <div>
-      <div className="mx-auto flex w-full justify-center gap-24 pt-72">
-        <SideNavigationMenu />
-        <div className="flex-1">
-          <div className="flex justify-between">
-            <p className="font-32px-bold">예약 내역</p>
-            <ReservationStatusDropdown
-              handleStatusChange={handleStatusChange}
-            />
-          </div>
-          <div>
-            <ReservationList status={status} />
-          </div>
+    <MyPageWrap>
+      <SideNavigationMenu />
+      <div className="flex-1">
+        <div className="flex justify-between">
+          <p className="font-32px-bold">예약 내역</p>
+          <ReservationStatusDropdown handleStatusChange={handleStatusChange} />
+        </div>
+        <div>
+          <ReservationList status={status} />
         </div>
       </div>
-    </div>
+    </MyPageWrap>
   );
 };
 

--- a/src/pages/reservation-history/index.tsx
+++ b/src/pages/reservation-history/index.tsx
@@ -4,6 +4,7 @@ import IconEmpty from "@/assets/svgs/ic_empty.svg";
 import Dropdown from "@/src/components/Dropdown";
 import ReservationHistoryCalendar from "@/src/components/ReservationHistory/ReservationHistoryCalendar";
 import SideNavigationMenu from "@/src/components/SideNavigationMenu/SideNavigationMenu";
+import MyPageWrap from "@/src/containers/MyPageWrap";
 import { useGetMyActivities } from "@/src/hooks/useMyActivities";
 import clsx from "clsx";
 import { useState } from "react";
@@ -20,80 +21,76 @@ const MyReservationHistory = () => {
   const [activityTitle, setActivityTitle] = useState("");
 
   return (
-    <div>
-      <div className="mb-120 flex w-full min-w-320 justify-center gap-24 pt-72">
-        <SideNavigationMenu />
-        <div className="flex-1">
-          <p className="font-32px-bold">예약 현황</p>
-          {myActivities ? (
-            <div className="mt-32">
-              <div className="relative mb-24 lg:mb-30">
-                <p className="font-14px-regular absolute left-12 top-[-10px] z-10 bg-gray-50 px-4">
-                  체험명
-                </p>
-                <Dropdown className="bg-white">
-                  <Dropdown.Trigger
-                    onClick={() => {
-                      setIsOpen(true);
-                    }}
-                    className={clsx(
-                      "font-16px-regular text-left",
-                      "flex h-56 w-full items-center justify-between",
-                      "rounded-4 border border-gray-500",
-                      "px-16 py-15",
-                    )}>
-                    {activityTitle || "체험을 선택하세요"}
-                    {isOpen ? <IconArrowUp /> : <IconArrowDown />}
-                  </Dropdown.Trigger>
-                  <Dropdown.Menu className="w-full bg-white">
-                    {myActivities && myActivities.length > 0 ? (
-                      myActivities.map((activity) => (
-                        <Dropdown.Item
-                          key={activity.id}
-                          className={clsx(
-                            "font-16px-regular flex justify-start py-15 pl-16 text-black",
-                            activityTitle === activity.title
-                              ? "bg-brand-400 text-white"
-                              : "hover:bg-gray-100",
-                          )}
-                          onClick={() => {
-                            setSelectedActivityId(activity.id);
-                            setActivityTitle(activity.title);
-                            setIsOpen(false);
-                          }}>
-                          {activity.title}
-                        </Dropdown.Item>
-                      ))
-                    ) : (
-                      <Dropdown.Item className="font-16px-regular flex justify-start py-15 pl-16 text-gray-500">
-                        체험이 없습니다.
-                      </Dropdown.Item>
-                    )}
-                  </Dropdown.Menu>
-                </Dropdown>
-              </div>
-              <div className="mb-20">
-                {selectedActivityId && (
-                  <ReservationHistoryCalendar activityId={selectedActivityId} />
-                )}
-              </div>
-            </div>
-          ) : (
-            <div
-              className={clsx(
-                "font-24px-medium mt-50 flex flex-col items-center text-gray-700",
-                "md:mt-64",
-                "lg:mt-80",
-              )}>
-              <IconEmpty />
-              <p className="font-18px-medium mt-37">
-                아직 등록한 체험이 없어요.
+    <MyPageWrap>
+      <SideNavigationMenu />
+      <div className="flex-1">
+        <p className="font-32px-bold">예약 현황</p>
+        {myActivities ? (
+          <div className="mt-32">
+            <div className="relative mb-24 lg:mb-30">
+              <p className="font-14px-regular absolute left-12 top-[-10px] z-10 bg-gray-50 px-4">
+                체험명
               </p>
+              <Dropdown className="bg-white">
+                <Dropdown.Trigger
+                  onClick={() => {
+                    setIsOpen(true);
+                  }}
+                  className={clsx(
+                    "font-16px-regular text-left",
+                    "flex h-56 w-full items-center justify-between",
+                    "rounded-4 border border-gray-500",
+                    "px-16 py-15",
+                  )}>
+                  {activityTitle || "체험을 선택하세요"}
+                  {isOpen ? <IconArrowUp /> : <IconArrowDown />}
+                </Dropdown.Trigger>
+                <Dropdown.Menu className="w-full bg-white">
+                  {myActivities && myActivities.length > 0 ? (
+                    myActivities.map((activity) => (
+                      <Dropdown.Item
+                        key={activity.id}
+                        className={clsx(
+                          "font-16px-regular flex justify-start py-15 pl-16 text-black",
+                          activityTitle === activity.title
+                            ? "bg-brand-400 text-white"
+                            : "hover:bg-gray-100",
+                        )}
+                        onClick={() => {
+                          setSelectedActivityId(activity.id);
+                          setActivityTitle(activity.title);
+                          setIsOpen(false);
+                        }}>
+                        {activity.title}
+                      </Dropdown.Item>
+                    ))
+                  ) : (
+                    <Dropdown.Item className="font-16px-regular flex justify-start py-15 pl-16 text-gray-500">
+                      체험이 없습니다.
+                    </Dropdown.Item>
+                  )}
+                </Dropdown.Menu>
+              </Dropdown>
             </div>
-          )}
-        </div>
+            <div className="mb-20">
+              {selectedActivityId && (
+                <ReservationHistoryCalendar activityId={selectedActivityId} />
+              )}
+            </div>
+          </div>
+        ) : (
+          <div
+            className={clsx(
+              "font-24px-medium mt-50 flex flex-col items-center text-gray-700",
+              "md:mt-64",
+              "lg:mt-80",
+            )}>
+            <IconEmpty />
+            <p className="font-18px-medium mt-37">아직 등록한 체험이 없어요.</p>
+          </div>
+        )}
       </div>
-    </div>
+    </MyPageWrap>
   );
 };
 

--- a/src/pages/reservation-history/index.tsx
+++ b/src/pages/reservation-history/index.tsx
@@ -24,7 +24,7 @@ const MyReservationHistory = () => {
     <MyPageWrap>
       <SideNavigationMenu />
       <div className="flex-1">
-        <p className="font-32px-bold">예약 현황</p>
+        <p className="font-32px-bold">내 체험 예약 현황</p>
         {myActivities ? (
           <div className="mt-32">
             <div className="relative mb-24 lg:mb-30">

--- a/src/pages/sign-in/index.tsx
+++ b/src/pages/sign-in/index.tsx
@@ -8,7 +8,7 @@ import TEST_USERS from "@/src/constants/testUsers";
 import SignPageWrap from "@/src/containers/SignPageWrap";
 import { useSignIn } from "@/src/queries/auth";
 import useUserStore from "@/src/stores/useUserStore";
-import { SignInProps } from "@/src/types/user";
+import type { SignInProps } from "@/src/types/user";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 

--- a/src/pages/sign-up/index.tsx
+++ b/src/pages/sign-up/index.tsx
@@ -4,15 +4,17 @@ import OauthSign from "@/src/components/OauthSign";
 import SignOptionSection from "@/src/components/SignOptionSection";
 import PATH_NAMES from "@/src/constants/pathname";
 import SignPageWrap from "@/src/containers/SignPageWrap";
+import useHydration from "@/src/hooks/useHydration";
 import { useSignUp } from "@/src/queries/auth";
 import useTempEmailStore from "@/src/stores/useTempEmailStore";
 import useUserStore from "@/src/stores/useUserStore";
-import { SignUpProps } from "@/src/types/user";
+import type { SignUpProps } from "@/src/types/user";
 import { useRouter } from "next/router";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 
 const SignUpRoute = () => {
   const router = useRouter();
+  const isHydrated = useHydration();
   const { userData } = useUserStore();
   const { mutate: signupFn, isPending: isPendingSignup } = useSignUp();
   const { email, clearEmail } = useTempEmailStore();
@@ -21,9 +23,13 @@ const SignUpRoute = () => {
     signupFn(data);
   };
 
-  useEffect(() => {
+  const handleEmailValue = useCallback(() => {
     if (email) clearEmail();
-  });
+  }, [email, clearEmail]);
+
+  useEffect(() => {
+    if (isHydrated) handleEmailValue();
+  }, [isHydrated, handleEmailValue]);
 
   useEffect(() => {
     if (userData) router.replace(PATH_NAMES.Root);
@@ -38,7 +44,7 @@ const SignUpRoute = () => {
 
         <Form.Field variant="email">
           <Form.Label>이메일</Form.Label>
-          <Form.Input placeholder="이메일을 입력해 주세요" />
+          <Form.Input placeholder="이메일을 입력해 주세요" value={email} />
         </Form.Field>
 
         <Form.Field variant="nickname">

--- a/src/queries/auth.tsx
+++ b/src/queries/auth.tsx
@@ -283,14 +283,16 @@ export const useOauthSignUp = () => {
           <PopupModal
             title={
               <p>
-                `${data.message}
+                {data.message}
                 <br />
-                로그인 페이지로 이동합니다.`
+                잠시후 로그인 페이지로 이동합니다.
               </p>
             }
           />,
         );
-        router.replace(PATH_NAMES.SignIn);
+        setTimeout(() => {
+          router.replace(PATH_NAMES.SignIn);
+        }, 3000);
       } else if (status && status >= 400 && status < 500) {
         setModalOpen(<PopupModal title={data.message} />);
       }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,10 +1,14 @@
 import api from "@/src/services/axios";
-import {
+import type {
   OauthActions,
   OauthSignInProps,
   OauthSignUpProps,
 } from "@/src/types/oauth";
-import { SignInProps, SignUpProps, UserPatchProps } from "@/src/types/user";
+import type {
+  SignInProps,
+  SignUpProps,
+  UserPatchProps,
+} from "@/src/types/user";
 import convertParamToQueryString from "@/src/utils/convertParamToQueryString";
 import axios from "axios";
 

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import api from "@/src/services/axios";
 import {
   OauthActions,

--- a/src/types/button.ts
+++ b/src/types/button.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 
 export type ButtonColorType =
   | "white_black"
@@ -23,7 +23,7 @@ interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   fontStyle?: ButtonTextSizeType;
   className?: string;
   disabled?: boolean;
-  onClick?: () => void;
+  onClick?: (() => void) | ((event: MouseEvent<HTMLButtonElement>) => void);
   children?: ReactNode;
 }
 

--- a/src/types/myReservations.ts
+++ b/src/types/myReservations.ts
@@ -10,7 +10,7 @@ export type ReservationStatus =
   | "canceled"
   | "completed"
   | "";
-export type ReservationRating = 0 | 1 | 2 | 3 | 4 | 5;
+export type ReservationRating = 1 | 2 | 3 | 4 | 5;
 
 /**
  * @description 내 예약 리스트 조회


### PR DESCRIPTION
# Resolved: #243

## 🔨 작업내역

- Popup, TwoButton 모달의 title 타입 확장
- 로그인, 회원가입, 내정보 커스텀 모달 적용
- 마이페이지 컨테이너 컴포넌트 생성
- 예약 내역, 내 체험 관리 카드 컴포넌트 스타일 수정
- 후기 작성 별점 최소값 1로 변경
- `에약 현황` 메뉴 `내 체험 예약 현황` 으로 이름 변경

## 🔊 전달사항

- 전달내용

## 📌 이슈사항

- 이슈내용

## 👩‍🔧 오류내역

- 오류내용

## 🎨 예시이미지

- 예시이미지 첨부


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 사용자 업데이트, 계정 해제, 인증 과정에 모달 기반 확인 단계를 추가했습니다.
  - 활동 예약 카드에 동적 링크 및 리뷰 제출 후 피드백이 개선되었습니다.
  - 새로운 레이아웃 컴포넌트를 도입하여 여러 페이지의 구성을 일관되게 관리합니다.

- **리팩토링**
  - 모달 타이틀이 문자열 외에도 다양한 콘텐츠를 수용할 수 있도록 개선했습니다.
  - 리뷰 폼의 별 평점 처리 로직과 아이콘 크기를 조정해 최소 평점을 1로 유지합니다.
  - 회원가입 페이지의 이메일 처리 로직에 수분 체크를 도입했습니다.

- **스타일**
  - 활동 카드, 드롭다운, 메뉴 항목의 시각적 표현을 업데이트하여 사용자 경험을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->