### PR TITLE
[fix/#244] 예약 가능한 시간 버튼 영역 스타일 수정

### DIFF
--- a/src/components/Modal/ReservationModal/Common/TimeSelector.tsx
+++ b/src/components/Modal/ReservationModal/Common/TimeSelector.tsx
@@ -30,7 +30,7 @@ const TimeSelector = ({ schedules }: Schedules) => {
           radius="8"
           gap="10"
           fontStyle="xxxl"
-          className={clsx("mr-10 h-46 px-12 py-10", {
+          className={clsx("mr-10 h-46 px-12 py-10 last:mr-0", {
             "bg-brand-500 text-white": isSelected,
             "border border-brand-500 text-brand-500": !isSelected,
           })}
@@ -66,7 +66,7 @@ const TimeSelector = ({ schedules }: Schedules) => {
   return (
     <div>
       <p className="font-18px-bold mt-20">예약 가능한 시간</p>
-      <div className="scrollbar-none mx-10 overflow-x-auto">
+      <div className="scrollbar-none overflow-x-auto">
         <div className="my-16 flex whitespace-nowrap">{renderSchedules()}</div>
       </div>
     </div>


### PR DESCRIPTION
# Resolved: #244

## 🔨 작업 내역
- '예약 가능한 시간' 버튼 영역의 좌우 여백 제거
- 마지막 버튼의 우측 여백 제거

<br/>

## 🔊 전달 사항
- @kanghyosung1
  예약 가능한 시간의 개수가 2개 이상일 때 잘린 부분 이후의 시간을 확인할 수 없습니다.
  이 부분 확인 후 수정 부탁 드립니다.
  <img src="https://github.com/user-attachments/assets/8eb0fa07-3385-411d-94bc-382143d0b1b1" width="50%" />

<br/>

## 🎨 예시 이미지
### 변경 전
<img src="https://github.com/user-attachments/assets/3ae4c396-589a-4d57-a11f-f6b2c06f5162" width="70%" />

### 변경 후
<img src="https://github.com/user-attachments/assets/f220314f-4e42-4ea4-b78e-5a007735b405" width="70%" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 예약 모달 내의 버튼 및 일정 영역 레이아웃 간격을 개선하여 보다 깔끔한 사용자 인터페이스를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->