### PR TITLE
[style/#258] 예약 확인 달력 일자 호버 시 커서 포인터 수정

### DIFF
--- a/src/components/ReservationHistory/ReservationHistoryCalendar.tsx
+++ b/src/components/ReservationHistory/ReservationHistoryCalendar.tsx
@@ -111,7 +111,7 @@ const MyDateHeader = ({ label, date }: { label: string; date: Date }) => {
       <button
         type="button"
         className={clsx(
-          "font-20px-semibold cursor-pointer border-none bg-transparent pl-12 pt-12 text-left text-gray-500",
+          "font-20px-semibold border-none bg-transparent pl-12 pt-12 text-left text-gray-500",
           // 모바일에서만 이벤트가 있을 때 다른 폰트 크기 적용
           eventsForDate?.length > 0 && "font-16px-semibold pl-8 pt-8",
         )}>
@@ -254,7 +254,7 @@ const ReservationHistoryCalendar = ({
           onSelectEvent={undefined}
           onSelectSlot={handleSelectSlot}
           selectable
-          className="w-full bg-white"
+          className="w-full cursor-pointer bg-white"
         />
       </div>
     </div>


### PR DESCRIPTION
# Resolved: #258 

## 🔨 작업내역

- 
![20250402_143754](https://github.com/user-attachments/assets/d6f95278-a1e3-4893-9a09-2a12f4b26934)

노란색 영역  호버시  포인트 나오게 수정


## 🎨 예시이미지

- 
![25_04_02_예약확인달력 호버시 포인터 확인](https://github.com/user-attachments/assets/5a628be6-f76e-4838-808f-5ab22aaa44c0)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- 예약 기록 달력에서 인터랙티브 요소의 스타일이 개선되어, 달력이 클릭 가능함을 더 명확하게 표시합니다.
	- 일부 버튼의 마우스 커서 표시가 제거되어, 사용자 인터페이스의 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->