### PR TITLE
[refactor/#266] 사용하지 않는 useRouter import문 삭제

### DIFF
--- a/src/queries/useActivities.ts
+++ b/src/queries/useActivities.ts
@@ -14,7 +14,6 @@ import {
 import { ActivityUpdateRequest } from "@/src/types/activitiesReservationType";
 import { ActivityDetailResponse } from "@/src/types/activitiesResponses";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
 
 export const useGetActivities = (activityId: number | undefined) => {
   const { data, isLoading, error } = useQuery<ActivityDetailResponse>({


### PR DESCRIPTION
# Resolved: #266 

## 🔨 작업 내역
- 사용하지 않는 `useRouter` import문 삭제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- 내부 코드 정리: 사용되지 않는 내비게이션 관련 의존성을 제거하여 코드베이스의 유지보수성과 안정성을 향상시켰습니다. 이 변경은 기존 기능에 영향을 주지 않으며, 향후 개선 작업의 기반을 마련합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->