### PR TITLE
[feat/#269] 예약내역 카드 동작 수정

### DIFF
--- a/src/components/MyPage/index.tsx
+++ b/src/components/MyPage/index.tsx
@@ -1,5 +1,5 @@
-import TwoButtonModal from "../Modal/TwoButtonModal";
 import Form from "@/src/components/Form";
+import TwoButtonModal from "@/src/components/Modal/TwoButtonModal";
 import useModalStore from "@/src/stores/useModalStore";
 import useUserStore from "@/src/stores/useUserStore";
 import type { ComponentProps } from "@/src/types/type";

--- a/src/components/MyReservations/ReservationCard.tsx
+++ b/src/components/MyReservations/ReservationCard.tsx
@@ -1,5 +1,5 @@
-import Loading from "../Loading";
 import Button from "@/src/components/Button/Button";
+import Loading from "@/src/components/Loading";
 import PopupModal from "@/src/components/Modal/PopupModal";
 import ReviewModal from "@/src/components/Modal/ReviewModal/ReviewModal";
 import PATH_NAMES from "@/src/constants/pathname";


### PR DESCRIPTION
# Resolved: #269 

## 🔨 작업내역

- 존재하지 않은 체험일 경우 모달 출력

## 🔊 전달사항

- 이제 예약내역에서 존재하지 않는 체험카드를 클릭하면 404 페이지로 이동하지 않고 모달이 뜹니다!

## 📌 이슈사항

- 이슈내용

## 👩‍🔧 오류내역

- 오류내용

## 🎨 예시이미지

![image](https://github.com/user-attachments/assets/cfcf4822-ee01-4150-a759-322b68fa6710)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
  - 데이터 로딩 시 진행 상태를 알리는 스피너가 표시되어 사용자에게 명확한 피드백을 제공합니다.
- **리팩토링**
  - 예약 항목의 렌더링 로직이 개선되어, 데이터 유무에 따라 링크 또는 클릭 동작이 보다 유연하게 처리됩니다.
- **변경 사항**
  - `TwoButtonModal` 컴포넌트의 import 경로가 상대 경로에서 절대 경로로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->