### PR TITLE
[fix/#275] 리뷰 내 프로필 이미지 1:1 비율로 수정

### DIFF
--- a/src/components/Review/ReviewList.tsx
+++ b/src/components/Review/ReviewList.tsx
@@ -28,7 +28,7 @@ const ReviewList = ({ fetchedReviews }: ReviewListProps) => {
                 height={45}
                 alt="후기 작성자 프로필 이미지"
                 className={clsx(
-                  "size-45 rounded-full border-brand-500 object-cover object-center",
+                  "aspect-square size-45 rounded-full border-brand-500 object-cover object-center",
                   { "shadow-md": review.user.profileImageUrl },
                 )}
               />


### PR DESCRIPTION
# Resolved: #275

## 🔨 작업 내역
- 리뷰 내 프로필 이미지 1:1 비율로 수정

<br/>

## 🔊 전달 사항
- 세로 이미지를 넣었을 때만 비율이 깨지는 문제 해결

<br/>

## 🎨 예시 이미지
세로 이미지 넣었을 때
- 기존
  ![image](https://github.com/user-attachments/assets/d3164380-9269-4374-841a-b76aa04e53c0)
- 변경
  ![image](https://github.com/user-attachments/assets/cd7e6520-a984-4cc6-accd-2cb53fb14046)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
	- 리뷰 화면의 이미지가 정사각형 비율로 표시되도록 스타일이 업데이트되었습니다.  
	  이 개선을 통해 이미지가 보다 균형 잡힌 비율로 나타납니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->