### PR TITLE
[feat/#277] ProfileUpload 컴포넌트가 언마운트 될 때 useProfileImageUrlStore 초기화

### DIFF
--- a/src/components/SideNavigationMenu/Common/ProfileUpload.tsx
+++ b/src/components/SideNavigationMenu/Common/ProfileUpload.tsx
@@ -4,7 +4,7 @@ import useProfileImageUrlStore from "@/src/stores/useProfileImageUrlStore";
 import { ProfileImageUrlResponse } from "@/src/types/users";
 import { useQueryClient } from "@tanstack/react-query";
 import Image from "next/image";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 
 interface Props {
   profileImageUrl?: string;
@@ -13,7 +13,7 @@ interface Props {
 const ProfileUpload = ({ profileImageUrl }: Props) => {
   const queryClient = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const { newProfileImageUrl, setNewProfileImageUrl } =
+  const { newProfileImageUrl, setNewProfileImageUrl, clearNewProfileImageUrl } =
     useProfileImageUrlStore();
 
   const { mutate } = useUploadProfileImage();
@@ -34,6 +34,12 @@ const ProfileUpload = ({ profileImageUrl }: Props) => {
       },
     });
   };
+
+  useEffect(() => {
+    return () => {
+      clearNewProfileImageUrl();
+    };
+  }, [clearNewProfileImageUrl]);
 
   return (
     <div className="relative size-160 border-0 bg-transparent p-0">


### PR DESCRIPTION
# Resolved: #277

## 🔨 작업내역

- ProfileUpload 컴포넌트가 언마운트 될 때 useProfileImageUrlStore 초기화

## 🔊 전달사항

- 이제 다른 계정으로 로그인 했을 때 이전 계정의 프로필이 보이지 않습니다!

## 📌 이슈사항

- 이슈내용

## 👩‍🔧 오류내역

- 오류내용

## 🎨 예시이미지

- 예시이미지 첨부


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 프로필 사진 업로드 후 임시 이미지 정보가 불필요하게 남지 않도록 자동 초기화 기능을 개선하여, 보다 일관된 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->