### PR TITLE
[fix/#280] 체험 상세 페이지 내 리뷰 하단 여백 수정

### DIFF
--- a/src/pages/activity/[[...activityId]]/index.tsx
+++ b/src/pages/activity/[[...activityId]]/index.tsx
@@ -126,7 +126,7 @@ const ActivitiesPage = ({ post }: { post: ActivityDetailResponse }) => {
         />
       </Head>
 
-      <div className="my-24 pb-300 md:my-32 lg:my-80">
+      <div className="my-24 pb-100 md:my-32 lg:my-80">
         <ActivityTitleSection
           category={category}
           title={title}


### PR DESCRIPTION
# Resolved: #280

## 🔨 작업 내역
- 체험 상세 페이지 내 리뷰 하단 여백 수정

<br/>

## 🔊 전달 사항
- `padding-bottom` 미적용 시 약간 답답해 보여서 `pb-100` 적용

<br/>

## 🎨 예시 이미지

### 기존: `pb-300`
![image](https://github.com/user-attachments/assets/caea0221-a882-44c7-bba8-40a1a700d924)

<br/>

### `padding-bottom` 미적용
![image](https://github.com/user-attachments/assets/57b8186d-489c-4e56-a419-8b7c22f094d0)

<br/>

### 변경: `pb-100`
![image](https://github.com/user-attachments/assets/b86666ad-43ab-44eb-b3e6-132637e2e033)