### PR TITLE
[feat/#262] 체험 수정 시 썸네일 삭제 기능 추가

### DIFF
--- a/src/components/MyActivities/ActivityConservation.tsx
+++ b/src/components/MyActivities/ActivityConservation.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import ActivityAddressInput from "@/src/components/ActivityInput/ActivityAddressInput";
 import ActivityCategoryInput from "@/src/components/ActivityInput/ActivityCategoryInput";
 import ActivityImageInput from "@/src/components/ActivityInput/ActivityImageInput";
@@ -17,6 +18,7 @@ import {
 import useModalStore from "@/src/stores/useModalStore";
 import type { ActivityUpdateRequest } from "@/src/types/activitiesReservationType";
 import type { ActivityFormDataType } from "@/src/types/activityFormDataType";
+import deleteThumbnail from "@/src/utils/deleteThumbnail";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
@@ -73,7 +75,7 @@ const ActivityConservation = ({ activityId }: RegisterPageProps) => {
         setModalOpen(
           <PopupModal
             title="체험이 등록되었습니다."
-            onConfirm ={() => {
+            onConfirm={() => {
               router.push(PATH_NAMES.MyActivities);
             }}
           />,
@@ -182,10 +184,19 @@ const ActivityConservation = ({ activityId }: RegisterPageProps) => {
         },
         {
           onSuccess: () => {
+            deleteThumbnail(activityId.toString())
+              .then((result) => {
+                if (!result.success) {
+                  console.error("썸네일 삭제 실패: ", result.message);
+                }
+              })
+              .catch((error) => {
+                console.error("썸네일 삭제 중 오류 발생: ", error);
+              });
             setModalOpen(
               <PopupModal
                 title="체험이 수정되었습니다."
-                onConfirm ={() => {
+                onConfirm={() => {
                   router.push(PATH_NAMES.MyActivities);
                 }}
               />,


### PR DESCRIPTION
# Resolved: #262 

## 🔨 작업내역

- 체험 수정 시 썸네일 삭제 기능 추가

## 🔊 전달사항

- 전달내용

## 📌 이슈사항

- 이슈내용

## 👩‍🔧 오류내역

- 오류내용

## 🎨 예시이미지

- 예시이미지 첨부


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 활동 업데이트 완료 후 관련 이미지(썸네일)가 자동으로 관리되어 불필요한 이미지가 제거됩니다.
  
- **Style**
	- 일부 인터페이스 요소의 포맷팅을 개선해 일관되고 깔끔한 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->