### PR TITLE
[fix/#284] FilterButton 상태 및 스크롤 로직 개선, focus 스타일 수정

### DIFF
--- a/src/components/Button/FilterButton.tsx
+++ b/src/components/Button/FilterButton.tsx
@@ -59,7 +59,7 @@ const FilterButton = () => {
         onMouseUp={handleMouseUp}
         onMouseLeave={handleMouseLeave}
         onMouseMove={isDrag ? handleMouseMove : undefined}
-        className="scrollbar-none flex overflow-scroll"
+        className="scrollbar-none flex overflow-scroll px-2 py-3"
         style={{
           gap: `${buttonGap}px`,
         }}>
@@ -75,7 +75,7 @@ const FilterButton = () => {
             }
             fontStyle={selectedCategory === category.value ? "xl" : "l"}
             className={clsx(
-              "font-14px-medium h-41 shrink-0 focus:ring-transparent",
+              "font-14px-medium h-41 shrink-0",
               "md:font-18px-medium md:h-58",
               "lg:font-18px-medium lg:h-58",
               isDrag ? "cursor-grabbing" : "cursor-pointer",

--- a/src/hooks/FilterButton/useCategoryState.ts
+++ b/src/hooks/FilterButton/useCategoryState.ts
@@ -5,10 +5,7 @@ import { useEffect, useState } from "react";
 const useCategoryState = (categories: Category[]) => {
   const router = useRouter();
 
-  const [selectedCategory, setSelectedCategory] = useState(
-    (router.query.category as string) || "",
-  );
-
+  const [selectedCategory, setSelectedCategory] = useState("");
   const [currentIndex, setCurrentIndex] = useState(() => {
     if (typeof window !== "undefined") {
       const storedIndex = localStorage.getItem("currentIndex");
@@ -45,19 +42,24 @@ const useCategoryState = (categories: Category[]) => {
   };
 
   useEffect(() => {
-    // currentIndex 값 변경 시 로컬스토리지에 저장
+    if (!router.isReady) return;
+
+    const queryCategory = router.query.category as string;
+    if (queryCategory) {
+      setSelectedCategory(queryCategory);
+      const index = categories.findIndex((c) => c.value === queryCategory);
+      setCurrentIndex(index !== -1 ? index : 0);
+    } else {
+      setSelectedCategory("");
+      setCurrentIndex(0);
+    }
+  }, [router.isReady, router.query.category, categories]);
+
+  useEffect(() => {
     if (typeof window !== "undefined") {
       localStorage.setItem("currentIndex", currentIndex.toString());
     }
   }, [currentIndex]);
-
-  // 필터 버튼 선택 안했을 경우, 초기화
-  useEffect(() => {
-    if (!router.query.category) {
-      setSelectedCategory("");
-      setCurrentIndex(0);
-    }
-  }, [router.query.category]);
 
   return { handleCategoryChange, selectedCategory, currentIndex };
 };

--- a/src/hooks/FilterButton/useDragScroll.ts
+++ b/src/hooks/FilterButton/useDragScroll.ts
@@ -57,27 +57,44 @@ const useDragScroll = ({
     }
   };
 
-  // 새로고침 시 자동 스크롤 및 위치 고정
   const router = useRouter();
   const hasCategoryQuery = Boolean(router.query.category);
-  const prevHasCategoryQuery = useRef(hasCategoryQuery); // 이전 hasCategoryQuery 값 추적
+  const prevHasCategoryQuery = useRef(hasCategoryQuery);
+  const hasScrolledOnInit = useRef(false);
+
+  // 스크롤 이동 로직
   useEffect(() => {
-    // 쿼리스트링이 없을 때만 리렌더링 발생
-    if (prevHasCategoryQuery.current) {
-      const scrollDistance = !hasCategoryQuery
-        ? 0
-        : slideWidth * currentIndex - buttonGap;
-      const container = document.getElementById("button-container");
-      if (container) {
-        container.scrollTo({
-          left: scrollDistance,
-          behavior: "smooth",
-        });
-      }
+    const container = document.getElementById("button-container");
+
+    if (!container || hasScrolledOnInit.current) return;
+
+    const isInitialLoadWithoutCategory =
+      typeof window !== "undefined" && !hasCategoryQuery;
+
+    const isPageReloadWithCategoryChanged =
+      prevHasCategoryQuery.current !== hasCategoryQuery;
+
+    if (
+      (isInitialLoadWithoutCategory && currentIndex === 0) ||
+      isPageReloadWithCategoryChanged
+    ) {
+      const scrollDistance = slideWidth * currentIndex;
+
+      container.scrollTo({
+        left: scrollDistance,
+        behavior: "smooth",
+      });
+
+      hasScrolledOnInit.current = true;
+      prevHasCategoryQuery.current = hasCategoryQuery;
     }
-    prevHasCategoryQuery.current = hasCategoryQuery;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [slideWidth, buttonGap, prevHasCategoryQuery, hasCategoryQuery]);
+  }, [slideWidth, buttonGap, currentIndex, hasCategoryQuery]);
+
+  useEffect(() => {
+    if (!hasCategoryQuery && prevHasCategoryQuery.current) {
+      hasScrolledOnInit.current = false;
+    }
+  }, [hasCategoryQuery]);
 
   return {
     isDrag,

--- a/src/hooks/FilterButton/useResponsiveLayout.ts
+++ b/src/hooks/FilterButton/useResponsiveLayout.ts
@@ -8,17 +8,23 @@ const useResponsiveLayout = (containerRef: React.RefObject<HTMLDivElement>) => {
   useEffect(() => {
     const handleResize = () => {
       const containerWidth = containerRef.current?.offsetWidth || 1152;
+
+      let newGap: number;
+      let newBtnWidth: number;
+
       if (window.innerWidth >= 1024) {
-        setButtonGap(20);
-        setButtonWidth((containerWidth - 6 * buttonGap) / 7);
+        newGap = 20;
+        newBtnWidth = (containerWidth - 6 * newGap) / 7;
       } else if (window.innerWidth >= 768) {
-        setButtonGap(18);
-        setButtonWidth(122);
+        newGap = 18;
+        newBtnWidth = 122;
       } else {
-        setButtonGap(15);
-        setButtonWidth(90);
+        newGap = 15;
+        newBtnWidth = 90;
       }
-      setSlideWidth(buttonWidth + buttonGap);
+      setButtonGap(newGap);
+      setButtonWidth(newBtnWidth);
+      setSlideWidth(newBtnWidth + newGap);
     };
     handleResize();
     window.addEventListener("resize", handleResize);


### PR DESCRIPTION
# Resolved: #284

## 🔨 작업 내역
- [x] 새로 고침 또는 로고 클릭 시, 필터 버튼 및 위치 초기화 문제 해결
  - 필터 버튼 선택 상태에서 새로 고침 시, 필터 버튼 유지 및 해당 버튼 위치로 자동 스크롤
  - 로고 클릭 시 필터 버튼 및 위치 초기화
- [x] focus 시 버튼 테두리가 보이지 않는 문제 해결

<br/>

## 🎨 예시 이미지
- 새로 고침 또는 로고 클릭 시, 필터 버튼 및 위치 초기화 문제 해결
   ![250610_filter_10 (1)](https://github.com/user-attachments/assets/24839e33-dd80-4519-ace2-5f313c90a57c)

<br/>

- focus 시 버튼 테두리가 보이지 않는 문제 해결
  ![250610_filter_11](https://github.com/user-attachments/assets/80bdaefc-362d-4c7b-9b5f-7b99c0121103)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
  - 스크롤 버튼 컨테이너에 좌우 및 상하 패딩이 추가되어 여백이 개선되었습니다.
  - 버튼의 포커스 링 스타일이 제거되어 더욱 깔끔한 버튼 디자인을 제공합니다.

- **버그 수정**
  - 카테고리 선택 및 스크롤 위치가 페이지 로드 및 쿼리 변경 시 더 일관되게 동작하도록 개선되었습니다.
  - 카테고리 상태와 스크롤 위치 동기화가 안정적으로 처리되어 예기치 않은 동작이 방지됩니다.

- **성능 및 동작 개선**
  - 초기 스크롤 동작이 중복되지 않도록 개선되어 부드럽고 일관된 스크롤 경험을 제공합니다.
  - 창 크기 변경 시 버튼 간격과 너비 계산 로직이 최적화되어 레이아웃 반응성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->