### PR TITLE
[fix/#286] 반응형 전환 및 새로고침 시 페이지네이션 오류 수정

### DIFF
--- a/src/components/Activity/AllActivityItem.tsx
+++ b/src/components/Activity/AllActivityItem.tsx
@@ -37,6 +37,7 @@ const AllActivityItem = ({
         <Link
           href={`${PATH_NAMES.Activity}/${id}
           `}
+          rel="nofollow"
           className="absolute inset-0"
           onClick={() => {
             showLoadingButtons(id);

--- a/src/components/Activity/PopularActivityItem.tsx
+++ b/src/components/Activity/PopularActivityItem.tsx
@@ -55,6 +55,7 @@ const PopularActivityItem = ({
       <Link
         href={`${PATH_NAMES.Activity}/${id}
 `}
+        rel="nofollow"
         onClick={() => {
           showLoadingButtons(id);
         }}

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -10,7 +10,9 @@ const usePagination = ({
   currentPage,
 }: PaginationProps) => {
   const router = useRouter();
-  const totalPages = Math.ceil(totalItems / itemCountPerPage);
+  const [totalPages, setTotalPages] = useState(
+    Math.ceil(totalItems / itemCountPerPage),
+  );
   const [start, setStart] = useState(1);
   const noPrev = start === 1;
   const noNext = start + pageCount - 1 >= totalPages;
@@ -18,21 +20,31 @@ const usePagination = ({
 
   // 현재 페이지에 맞춰 시작 페이지(start) 계산
   useEffect(() => {
+    // currentPage가 변경될 때마다 시작 페이지를 계산
     const newStart = Math.floor((currentPage - 1) / pageCount) * pageCount + 1;
-    if (start !== newStart) setStart(newStart);
+    if (start !== newStart) setStart(newStart); // 새로운 시작 페이지로 업데이트
   }, [currentPage, pageCount, start]);
+
+  // itemCountPerPage 혹은 totalItems가 바뀌면 totalPages 재계산
+  useEffect(() => {
+    const newTotalPages = Math.ceil(totalItems / itemCountPerPage);
+    setTotalPages(newTotalPages);
+  }, [itemCountPerPage, totalItems]);
 
   // 화면 크기 변경 시, 페이지가 유효한 범위 내에 있도록 자동 조정
   useEffect(() => {
+    if (totalPages < 1) return () => {};
+
     const handleResize = () => {
       if (currentPage > totalPages) {
         router.push(`?page=${totalPages}`);
       }
     };
 
+    handleResize();
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
-  }, [currentPage, totalPages, router]);
+  }, [currentPage, router, totalPages]);
 
   // 페이지 이동
   const navigateToPage = (page: number): void => {

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -16,7 +16,7 @@ export const getStaticProps = async () => {
   const popularActivitiesInitialData = await listPopularActivities(1);
   const { totalCount } = popularActivitiesInitialData;
 
-  const allActivities = await listAllActivities("latest");
+  const allActivities = await listAllActivities("latest", totalCount);
 
   return {
     props: {
@@ -58,15 +58,17 @@ const Home = ({
   const [allActivities, setAllActivities] = useState(initialAllActivities);
 
   useEffect(() => {
+    if (!totalCount) return;
+
     setSelectedCategory(category);
 
     const fetchActivities = async () => {
-      const data = await listAllActivities(sort, category);
+      const data = await listAllActivities(sort, totalCount, category);
       setAllActivities(data);
     };
 
     fetchActivities();
-  }, [category, sort]);
+  }, [category, totalCount, sort]);
 
   const { activities: allActivityList } = allActivities;
 

--- a/src/pages/review/index.tsx
+++ b/src/pages/review/index.tsx
@@ -1,9 +1,15 @@
 import Review from "@/src/components/Review";
-import { listAllActivities } from "@/src/services/activities";
+import {
+  listAllActivities,
+  listPopularActivities,
+} from "@/src/services/activities";
 import { InferGetServerSidePropsType } from "next";
 
 export const getServerSideProps = async () => {
-  const response = await listAllActivities("latest");
+  const popularActivitiesInitialData = await listPopularActivities(1);
+  const { totalCount } = popularActivitiesInitialData;
+
+  const response = await listAllActivities("latest", totalCount);
   const { activities } = response;
 
   if (!activities || activities.length === 0) {

--- a/src/services/activities.ts
+++ b/src/services/activities.ts
@@ -20,14 +20,15 @@ import { ActivityDetailResponse } from "@/src/types/activitiesResponses";
  */
 export const listAllActivities = async (
   sort: string,
+  size: number,
   category?: string,
 ): Promise<ActivitiesResponse> => {
   let url;
 
   if (category) {
-    url = `/activities?method=offset&sort=${sort}&category=${category}`;
+    url = `/activities?method=offset&sort=${sort}&size=${size}&category=${category}`;
   } else {
-    url = `/activities?method=offset&sort=${sort}`;
+    url = `/activities?method=offset&sort=${sort}&size=${size}`;
   }
 
   try {


### PR DESCRIPTION
# Resolved: #286 

## 🔨 작업 내역
- [x] 전체 체험 개수 올바르게 가져오도록 API 로직 수정
   - 기존: 최대 20개
   - 변경: 등록된 모든 체험
- [x] 반응형 전환 시 유효하지 않은 페이지 처리
- [x] 새로고침 시 페이지 번호가 초기화되는 문제 해결
- [x] 체험 이미지 hover 시 불필요한 fetch 요청 발생 문제 해결

<br/>

## 🎨 예시 이미지
![250528_pagination (1)](https://github.com/user-attachments/assets/baf27b30-0a66-47d5-b7bb-5ce15ab5f0bf)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 페이지네이션 및 활동 목록 페이지에서 라우터 준비 이전에 잘못된 페이지 초기화 문제를 해결했습니다.
	- 활동이 없을 때 "not found" 메시지의 표시 조건이 개선되었습니다.
- **기능 개선**
	- 인기 활동 및 전체 활동 항목의 링크에 검색 엔진 크롤링 방지 속성(rel="nofollow")이 추가되었습니다.
	- 페이지네이션 로직이 더 견고하게 동작하도록 개선되었습니다.
- **기타**
	- 활동 목록 API 호출 시 size 파라미터가 추가되어 데이터 요청이 더 명확하게 이루어집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->