### PR TITLE
[fix/#290] 체험 등록 후 잘못된 revalidate 경로로 인한 500 에러 해결

### DIFF
--- a/src/queries/useActivities.ts
+++ b/src/queries/useActivities.ts
@@ -35,7 +35,7 @@ export const useCreateActivity = () => {
     mutationFn: (data: CreateActivityProps) => createActivity(data),
     onSuccess: async () => {
       try {
-        const response = await fetch(`/api/revalidate?path=home`, {
+        const response = await fetch(`/api/revalidate?path=/home`, {
           method: "POST",
         });
         if (!response.ok) {


### PR DESCRIPTION
# Resolved: #290 

## 🔨 작업 내역
- [x] 체험 등록 후 잘못된 revalidate 경로로 인한 500 에러 해결

<br/>

## 👩‍🔧 오류 내역
![image](https://github.com/user-attachments/assets/dd40e1bf-8b16-4e5a-98c7-60aeebb40f8e)

<br/>

## 🎨 예시 이미지
![250611_revalidate](https://github.com/user-attachments/assets/717f9b49-7792-4fb1-a747-7b83a9f459a5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 활동 생성 후 데이터 갱신 요청 시 경로 파라미터에 슬래시(`/`)가 누락되는 문제를 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->